### PR TITLE
GH-174

### DIFF
--- a/spring-data-jdbc-ydb/pom.xml
+++ b/spring-data-jdbc-ydb/pom.xml
@@ -51,7 +51,7 @@
 
         <junit5.version>5.10.2</junit5.version>
         <lombok.version>1.18.30</lombok.version>
-        <spring.version>3.2.1</spring.version>
+        <spring.version>3.4.0</spring.version>
         <liquibase.version>4.24.0</liquibase.version>
 
         <ydb.sdk.version>2.2.9</ydb.sdk.version>

--- a/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/AbstractYdbJdbcConfiguration.java
+++ b/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/AbstractYdbJdbcConfiguration.java
@@ -1,6 +1,7 @@
 package tech.ydb.data.repository.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jdbc.core.convert.DefaultJdbcTypeFactory;
 import org.springframework.data.jdbc.core.convert.JdbcArrayColumns;
@@ -15,9 +16,12 @@ import tech.ydb.data.core.convert.YdbMappingJdbcConverter;
 
 /**
  * @author Madiyar Nurgazin
+ * @author Mikhail Polivakha
  */
 @Configuration
+@Import(JdbcRepositoryBeanPostProcessor.class)
 public class AbstractYdbJdbcConfiguration extends AbstractJdbcConfiguration {
+
     @Override
     public JdbcConverter jdbcConverter(
             JdbcMappingContext mappingContext,

--- a/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/JdbcRepositoryBeanPostProcessor.java
+++ b/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/JdbcRepositoryBeanPostProcessor.java
@@ -1,0 +1,45 @@
+package tech.ydb.data.repository.config;
+
+import java.util.Arrays;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactoryBean;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.util.ReflectionUtils;
+
+import tech.ydb.data.repository.ViewIndex;
+
+/**
+ * Enabling the exposure of the metadata for the {@link JdbcRepositoryFactoryBean}. Enables
+ * only for those {@link RepositoryFactoryBeanSupport factory beans} that have any {@link ViewIndex}
+ * annotated methods.
+ *
+ * @author Mikhail Polivakha
+ */
+@SuppressWarnings("rawtypes")
+public class JdbcRepositoryBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof JdbcRepositoryFactoryBean rfbs && hasAnyViewIndexMethods(rfbs)) {
+            rfbs.setExposeMetadata(true);
+        }
+        return bean;
+    }
+
+    /**
+     * Unfortunately, {@link JdbcRepositoryFactoryBean#getRepositoryInformation()} call is not possible at this stage, since
+     * {@link RepositoryFactoryBeanSupport#factory} is not initialized at this point yet. Still, we have
+     * to use {@link BeanPostProcessor#postProcessBeforeInitialization(Object, String)} since the
+     * {@link RepositoryFactoryBeanSupport#setExposeMetadata(boolean) expose metadata} call needs to be done before the {@link InitializingBean#afterPropertiesSet()}
+     * to be propagated into the underlying {@link org.springframework.data.repository.core.support.RepositoryFactorySupport factory support}
+     */
+    private static boolean hasAnyViewIndexMethods(JdbcRepositoryFactoryBean rfbs) {
+        return Arrays
+          .stream(ReflectionUtils.getAllDeclaredMethods(rfbs.getObjectType()))
+          .anyMatch(method -> AnnotationUtils.getAnnotation(method, ViewIndex.class) != null);
+    }
+}

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/YdbJdbcConfiguration.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/YdbJdbcConfiguration.java
@@ -8,9 +8,13 @@ import tech.ydb.data.repository.config.AbstractYdbJdbcConfiguration;
 
 /**
  * @author Madiyar Nurgazin
+ * @author Mikhail Polivakha
  */
 @Configuration
-@EnableJdbcRepositories
+@EnableJdbcRepositories(
+  considerNestedRepositories = true,
+  basePackages = "tech.ydb.data"
+)
 @EnableJdbcAuditing
 @Import(AbstractYdbJdbcConfiguration.class)
 public class YdbJdbcConfiguration {}

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/repository/config/JdbcRepositoryBeanPostProcessorTest.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/repository/config/JdbcRepositoryBeanPostProcessorTest.java
@@ -1,0 +1,72 @@
+package tech.ydb.data.repository.config;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.util.ReflectionUtils;
+
+import tech.ydb.data.YdbBaseTest;
+import tech.ydb.data.repository.ViewIndex;
+
+/**
+ * Tests for {@link JdbcRepositoryBeanPostProcessor}.
+ *
+ * @author Mikhail Polivakha
+ */
+class JdbcRepositoryBeanPostProcessorTest extends YdbBaseTest {
+
+    @Autowired
+    private RepositoryFactoryBeanSupport<UserRepository, User, Long> userFactoryBeanSupport;
+
+    @Autowired
+    private RepositoryFactoryBeanSupport<AddressRepository, Address, Long> addressFactoryBeanSupport;
+
+    @Test
+    void shouldExposeMetadataOnlyForRepositoriesWithViewIndexMethods() {
+
+        // given.
+        Field exposeMetadataField = ReflectionUtils.findField(RepositoryFactoryBeanSupport.class, "exposeMetadata");
+        exposeMetadataField.setAccessible(true);
+
+        // when.
+        Object userFactoryExposedMetadata = ReflectionUtils.getField(exposeMetadataField, userFactoryBeanSupport);
+        Object addressFactoryExposedMetadata = ReflectionUtils.getField(exposeMetadataField, addressFactoryBeanSupport);
+
+        // then.
+        Assertions.assertThat(userFactoryExposedMetadata).isEqualTo(true);
+        Assertions.assertThat(addressFactoryExposedMetadata).isEqualTo(false);
+    }
+
+    @Table
+    static class User {
+
+        @Id
+        private Long id;
+
+        private String name;
+    }
+
+    @Table
+    static class Address {
+
+        @Id
+        private Long id;
+    }
+
+    interface UserRepository extends CrudRepository<User, Long> {
+
+        @ViewIndex(indexName = "name_authors_index", tableName = "authors")
+        Optional<User> findUserByName(String name);
+    }
+
+    interface AddressRepository extends CrudRepository<Address, Long> {
+
+    }
+}


### PR DESCRIPTION
**WIP**

Solving #174. 

Spring Data, as of 3.4, does not expose the repository invocation metadata unless explicitly specified to do so. The motivation for this change is that adding an Advisor for exposing methods is a bit resource intensive. 

Unfortunately, we cannot really do anything in the dialect itself, since the `Dialect` by its design, is supposed to work on SQL level only. That is to say, it does not know anything about `PersistentEntity` or the `QueryExecutorMethodInterceptor`.

So, what we're actually doing is - **we're enabling the metadata exposure per `RepositoryFactoryBeanSupport`-basis**. That is to say, we do not enable it for every repository in the system. We're just enabling it for those that require that, in our case, annotated with `@ViewIndex`
