### PR TITLE
Handle null values in IntervalConverter and TimestampConverter in jOOQ

### DIFF
--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/Interval64Binding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/Interval64Binding.java
@@ -44,7 +44,7 @@ public class Interval64Binding extends AbstractBinding<ULong, Duration> {
 
         @Override
         public Duration from(ULong databaseObject) {
-            return Duration.of(databaseObject.longValue(), ChronoUnit.MICROS);
+            return databaseObject == null ? null : Duration.of(databaseObject.longValue(), ChronoUnit.MICROS);
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/Interval64Binding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/Interval64Binding.java
@@ -49,7 +49,7 @@ public class Interval64Binding extends AbstractBinding<ULong, Duration> {
 
         @Override
         public ULong to(Duration userObject) {
-            return ULong.valueOf(TimeUnit.NANOSECONDS.toMicros(userObject.toNanos()));
+            return userObject == null ? null : ULong.valueOf(TimeUnit.NANOSECONDS.toMicros(userObject.toNanos()));
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
@@ -39,10 +39,7 @@ public final class IntervalBinding extends AbstractBinding<YearToSecond, Duratio
     private static class IntervalConverter implements Converter<YearToSecond, Duration> {
         @Override
         public Duration from(YearToSecond databaseObject) {
-            if (databaseObject == null) {
-                return null;
-            }
-            return databaseObject.toDuration();
+            return databaseObject == null ? null : databaseObject.toDuration();
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
@@ -44,7 +44,7 @@ public final class IntervalBinding extends AbstractBinding<YearToSecond, Duratio
 
         @Override
         public YearToSecond to(Duration userObject) {
-            return YearToSecond.valueOf(userObject);
+            return userObject == null ? null : YearToSecond.valueOf(userObject);
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/IntervalBinding.java
@@ -39,6 +39,9 @@ public final class IntervalBinding extends AbstractBinding<YearToSecond, Duratio
     private static class IntervalConverter implements Converter<YearToSecond, Duration> {
         @Override
         public Duration from(YearToSecond databaseObject) {
+            if (databaseObject == null) {
+                return null;
+            }
             return databaseObject.toDuration();
         }
 

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
@@ -39,10 +39,7 @@ public final class TimestampBinding extends AbstractBinding<LocalDateTime, Insta
     private static class TimestampConverter implements Converter<LocalDateTime, Instant> {
         @Override
         public Instant from(LocalDateTime databaseObject) {
-            if (databaseObject == null) {
-                return null;
-            }
-            return databaseObject.toInstant(ZoneOffset.UTC);
+            return databaseObject == null ? null : databaseObject.toInstant(ZoneOffset.UTC);
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
@@ -39,6 +39,9 @@ public final class TimestampBinding extends AbstractBinding<LocalDateTime, Insta
     private static class TimestampConverter implements Converter<LocalDateTime, Instant> {
         @Override
         public Instant from(LocalDateTime databaseObject) {
+            if (databaseObject == null) {
+                return null;
+            }
             return databaseObject.toInstant(ZoneOffset.UTC);
         }
 

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/TimestampBinding.java
@@ -44,7 +44,7 @@ public final class TimestampBinding extends AbstractBinding<LocalDateTime, Insta
 
         @Override
         public LocalDateTime to(Instant userObject) {
-            return LocalDateTime.ofInstant(userObject, ZoneOffset.UTC);
+            return userObject == null ? null : LocalDateTime.ofInstant(userObject, ZoneOffset.UTC);
         }
 
         @Override

--- a/jooq-dialect/src/main/java/tech/ydb/jooq/binding/YsonBinding.java
+++ b/jooq-dialect/src/main/java/tech/ydb/jooq/binding/YsonBinding.java
@@ -39,7 +39,7 @@ public final class YsonBinding extends AbstractBinding<Object, YSON> {
     private static class YsonConverter implements Converter<Object, YSON> {
         @Override
         public YSON from(Object databaseObject) {
-            return (YSON) databaseObject;
+            return databaseObject == null ? null : (YSON) databaseObject;
         }
 
         @Override


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When trying to upsert/update timestamp field in jOOQ repository, it couses NullPointerException

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now it is possible to upsert/update Timestamp fields to null
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
