### PR TITLE
feat: Map Ydb constraint violation exception to hibernate specific exception

### DIFF
--- a/hibernate-dialect-v6/CHANGELOG.md
+++ b/hibernate-dialect-v6/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add YDB constraint violation exception mapping to hibernate specific exception
 - Disable ordinal SELECT item references (`ORDER BY 1`, `GROUP BY 1`) — YDB does not support them
 - Add `'u` suffix to string literals to everywhere used Utf8 type instead of String. For escape symbol added custom translation to it had String type, not Utf8.
 - Support `lower`, `upper` and `concat` functions

--- a/hibernate-dialect-v6/src/main/java/tech/ydb/hibernate/dialect/YdbDialect.java
+++ b/hibernate-dialect-v6/src/main/java/tech/ydb/hibernate/dialect/YdbDialect.java
@@ -14,6 +14,8 @@ import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitOffsetLimitHandler;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.mapping.Constraint;
 import org.hibernate.mapping.ForeignKey;
 import org.hibernate.mapping.Index;
@@ -26,6 +28,8 @@ import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.BasicType;
+
+import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
 import static org.hibernate.type.SqlTypes.BIGINT;
 import static org.hibernate.type.SqlTypes.BINARY;
 import static org.hibernate.type.SqlTypes.BIT;
@@ -474,6 +478,20 @@ public class YdbDialect extends Dialect {
     public void appendLiteral(SqlAppender appender, String literal) {
         super.appendLiteral(appender, literal);
         appender.append('u');
+    }
+
+    @Override
+    public SQLExceptionConversionDelegate buildSQLExceptionConversionDelegate() {
+        return (sqlException, message, sql) -> {
+            String msg = sqlException.getMessage();
+
+            return switch (extractErrorCode(sqlException)) {
+                case 400120 -> msg != null && msg.contains("Conflict with existing key")
+                        ? new ConstraintViolationException(message, sqlException, sql, null)
+                        : null;
+                default -> null;
+            };
+        };
     }
 
     private static int ydbDecimal(int precision, int scale) {

--- a/hibernate-dialect-v6/src/test/java/tech/ydb/hibernate/exception/DupTestEntity.java
+++ b/hibernate-dialect-v6/src/test/java/tech/ydb/hibernate/exception/DupTestEntity.java
@@ -1,0 +1,21 @@
+package tech.ydb.hibernate.exception;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Table(name = "exception_test_dup")
+@NoArgsConstructor
+@AllArgsConstructor
+public class DupTestEntity {
+
+    @Id
+    private int id;
+
+    private String name;
+}

--- a/hibernate-dialect-v6/src/test/java/tech/ydb/hibernate/exception/ExceptionConversionTest.java
+++ b/hibernate-dialect-v6/src/test/java/tech/ydb/hibernate/exception/ExceptionConversionTest.java
@@ -1,0 +1,54 @@
+package tech.ydb.hibernate.exception;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import tech.ydb.test.junit5.YdbHelperExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.ydb.hibernate.TestUtils.*;
+
+class ExceptionConversionTest {
+
+    @RegisterExtension
+    private static final YdbHelperExtension ydb = new YdbHelperExtension();
+
+    @BeforeAll
+    static void setUp() {
+        SESSION_FACTORY = basedConfiguration()
+                .setProperty(AvailableSettings.URL, jdbcUrl(ydb))
+                .setProperty(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION, "none")
+                .addAnnotatedClass(DupTestEntity.class)
+                .buildSessionFactory();
+
+        inTransaction(session -> {
+            session.createNativeQuery(
+                    """
+                        CREATE TABLE exception_test_dup (
+                            id    Int32  NOT NULL,
+                            name  Text,
+                            PRIMARY KEY (id),
+                            INDEX idx_dup_name GLOBAL UNIQUE ON (name)
+                        )"""
+            ).executeUpdate();
+        });
+    }
+
+    @Test
+    void duplicatePrimaryKeyThrowsConstraintViolationException() {
+        inTransaction(session -> session.persist(new DupTestEntity(1, "pk-first")));
+
+        assertThrows(ConstraintViolationException.class,
+                () -> inTransaction(session -> session.persist(new DupTestEntity(1, "pk-duplicate"))));
+    }
+
+    @Test
+    void duplicateUniqueIndexThrowsConstraintViolationException() {
+        inTransaction(session -> session.persist(new DupTestEntity(10, "unique-value")));
+
+        assertThrows(ConstraintViolationException.class,
+                () -> inTransaction(session -> session.persist(new DupTestEntity(11, "unique-value"))));
+    }
+}

--- a/hibernate-dialect-v7/CHANGELOG.md
+++ b/hibernate-dialect-v7/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add YDB constraint violation exception mapping to hibernate specific exception 
 - Added `'u` suffix to string literals to everywhere used Utf8 type instead of String. For escape symbol added custom translation to it had String type, not Utf8.
 - Disable ordinal SELECT item references (`ORDER BY 1`, `GROUP BY 1`) — YDB does not support them
 

--- a/hibernate-dialect-v7/src/main/java/tech/ydb/hibernate/dialect/YdbDialect.java
+++ b/hibernate-dialect-v7/src/main/java/tech/ydb/hibernate/dialect/YdbDialect.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.dialect.identity.IdentityColumnSupport;
 import org.hibernate.dialect.pagination.LimitHandler;
@@ -23,6 +25,7 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAppender;
 import org.hibernate.tool.schema.spi.Exporter;
+import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
 import static org.hibernate.type.SqlTypes.BIGINT;
 import static org.hibernate.type.SqlTypes.BINARY;
 import static org.hibernate.type.SqlTypes.BIT;
@@ -473,6 +476,20 @@ public class YdbDialect extends Dialect {
     public void appendLiteral(SqlAppender appender, String literal) {
         super.appendLiteral(appender, literal);
         appender.append('u');
+    }
+
+    @Override
+    public SQLExceptionConversionDelegate buildSQLExceptionConversionDelegate() {
+        return (sqlException, message, sql) -> {
+            String msg = sqlException.getMessage();
+
+            return switch (extractErrorCode(sqlException)) {
+                case 400120 -> msg != null && msg.contains("Conflict with existing key")
+                        ? new ConstraintViolationException(message, sqlException, sql, ConstraintViolationException.ConstraintKind.UNIQUE, null)
+                        : null;
+                default -> null;
+            };
+        };
     }
 
     private static int ydbDecimal(int precision, int scale) {

--- a/hibernate-dialect-v7/src/test/java/tech/ydb/hibernate/exception/DupTestEntity.java
+++ b/hibernate-dialect-v7/src/test/java/tech/ydb/hibernate/exception/DupTestEntity.java
@@ -1,0 +1,21 @@
+package tech.ydb.hibernate.exception;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Table(name = "exception_test_dup")
+@NoArgsConstructor
+@AllArgsConstructor
+public class DupTestEntity {
+
+    @Id
+    private int id;
+
+    private String name;
+}

--- a/hibernate-dialect-v7/src/test/java/tech/ydb/hibernate/exception/ExceptionConversionTest.java
+++ b/hibernate-dialect-v7/src/test/java/tech/ydb/hibernate/exception/ExceptionConversionTest.java
@@ -1,0 +1,59 @@
+package tech.ydb.hibernate.exception;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import tech.ydb.test.junit5.YdbHelperExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.ydb.hibernate.TestUtils.*;
+
+class ExceptionConversionTest {
+
+    @RegisterExtension
+    private static final YdbHelperExtension ydb = new YdbHelperExtension();
+
+    @BeforeAll
+    static void setUp() {
+        SESSION_FACTORY = basedConfiguration()
+                .setProperty(AvailableSettings.URL, jdbcUrl(ydb))
+                .setProperty(AvailableSettings.JAKARTA_HBM2DDL_DATABASE_ACTION, "none")
+                .addAnnotatedClass(DupTestEntity.class)
+                .buildSessionFactory();
+
+        inTransaction(session -> {
+            session.createNativeQuery(
+                    """
+                            CREATE TABLE exception_test_dup (
+                                id    Int32  NOT NULL,
+                                name  Text,
+                                PRIMARY KEY (id),
+                                INDEX idx_dup_name GLOBAL UNIQUE ON (name)
+                            )"""
+            ).executeUpdate();
+        });
+    }
+
+    @Test
+    void duplicatePrimaryKeyThrowsConstraintViolationException() {
+        inTransaction(session -> session.persist(new DupTestEntity(1, "pk-first")));
+
+        ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
+                () -> inTransaction(session -> session.persist(new DupTestEntity(1, "pk-duplicate"))));
+
+        assertEquals(ConstraintViolationException.ConstraintKind.UNIQUE, ex.getKind());
+    }
+
+    @Test
+    void duplicateUniqueIndexThrowsConstraintViolationException() {
+        inTransaction(session -> session.persist(new DupTestEntity(10, "unique-value")));
+
+        ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
+                () -> inTransaction(session -> session.persist(new DupTestEntity(11, "unique-value"))));
+
+        assertEquals(ConstraintViolationException.ConstraintKind.UNIQUE, ex.getKind());
+    }
+}


### PR DESCRIPTION

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

YDB exceptions are not mapped to Hibernate specific exception

## What is the new behavior?

Implement `buildSQLExceptionConversionDelegate` to handle `ConstraintViolationException`

## Other information
inspired by Hibernate OracleDialect implementation

https://github.com/hibernate/hibernate-orm/blob/932d7b517a89eea88e5c3cd9115106798d0d6100/hibernate-core/src/main/java/org/hibernate/dialect/OracleDialect.java#L1259