### PR TITLE
Add spring-ydb-retry module (v0.10.0)

### DIFF
--- a/spring-ydb-retry/CHANGELOG.md
+++ b/spring-ydb-retry/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.0 ##
+
+- Renamed the `maxRetries` retry setting to `maxAttempts`, which now counts the total number of attempts including the initial execution (aligned with Spring Retry semantics). The `ydb.transaction.retry.max-retries` property is renamed to `ydb.transaction.retry.max-attempts`.
+- `@YdbTransactional` override attributes now use `0` (instead of `-1`) to inherit the global configuration value; negative values are rejected.
+
 ## 0.9.0 ##
 
 - First version of the plugin

--- a/spring-ydb-retry/README.md
+++ b/spring-ydb-retry/README.md
@@ -1,5 +1,9 @@
 # Spring YDB Retry
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ydb-platform/ydb-java-dialects/blob/main/LICENSE.md)
+[![Maven metadata URL](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Ftech%2Fydb%2Fspring-ydb-retry%2Fmaven-metadata.xml)](https://mvnrepository.com/artifact/tech.ydb/spring-ydb-retry)
+[![CI](https://img.shields.io/github/actions/workflow/status/ydb-platform/ydb-java-dialects/ci-spring-ydb-retry.yaml?branch=main&label=CI)](https://github.com/ydb-platform/ydb-java-dialects/actions/workflows/ci-spring-ydb-retry.yaml)
+
 ## Overview
 
 This project is a Spring Boot auto-configuration module that provides automatic retry
@@ -8,7 +12,7 @@ for transactional operations with [YDB](https://ydb.tech).
 ### Features
 
 - Automatic retry of failed `@Transactional` methods on YDB retryable status codes
-- `@YdbTransactional` annotation with per-method retry settings (maxRetries, backoff, idempotency)
+- `@YdbTransactional` annotation with per-method retry settings (maxAttempts, backoff, idempotency)
 - Dual backoff strategy (fast/slow) with jitter tailored to YDB error semantics
 - Idempotent mode for extended retry coverage on non-deterministic status codes
 - Fully configurable via `application.properties`
@@ -27,6 +31,7 @@ for transactional operations with [YDB](https://ydb.tech).
 For Maven, add the following dependency to your pom.xml:
 
 ```xml
+
 <dependency>
     <groupId>tech.ydb</groupId>
     <artifactId>spring-ydb-retry</artifactId>
@@ -54,9 +59,10 @@ Use `@YdbTransactional` as a drop-in replacement for `@Transactional` with addit
 retry parameters:
 
 ```java
-@YdbTransactional(maxRetries = 5, idempotent = true)
+
+@YdbTransactional(maxAttempts = 5, idempotent = true)
 public void save(User user) {
-    // retried up to 5 times on YDB retryable errors
+    // executed up to 5 times in total (initial attempt + up to 4 retries) on YDB retryable errors
 }
 ```
 
@@ -67,14 +73,11 @@ Configure retry behavior in `application.properties`:
 ```properties
 # Enable/disable retry (default: true)
 ydb.transaction.retry.enabled=true
-
-# Maximum retry attempts (default: 10)
-ydb.transaction.retry.max-retries=10
-
+# Maximum total attempts, counting the initial execution (default: 10)
+ydb.transaction.retry.max-attempts=10
 # Backoff settings for slow errors
 ydb.transaction.retry.slow-backoff-base-ms=50
 ydb.transaction.retry.slow-cap-backoff-ms=5000
-
 # Backoff settings for fast errors
 ydb.transaction.retry.fast-backoff-base-ms=5
 ydb.transaction.retry.fast-cap-backoff-ms=500

--- a/spring-ydb-retry/pom.xml
+++ b/spring-ydb-retry/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>tech.ydb</groupId>
     <artifactId>spring-ydb-retry</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
 
     <name>Spring YDB Retry</name>

--- a/spring-ydb-retry/slo/README.md
+++ b/spring-ydb-retry/slo/README.md
@@ -104,7 +104,7 @@ Environment variables for the app containers:
 | `SERVER_PORT`                       | 8080                     | HTTP port                                         |
 | `SPRING_DATASOURCE_URL`             | -                        | YDB JDBC URL                                      |
 | `YDB_TRANSACTION_RETRY_ENABLED`     | true                     | Enable/disable retry                              |
-| `YDB_TRANSACTION_RETRY_MAX_RETRIES` | 10                       | Max retry attempts                                |
+| `YDB_TRANSACTION_RETRY_MAX_ATTEMPTS` | 10                      | Max total attempts (incl. initial execution)      |
 | `SLO_RUN_ID`                        | auto                     | Shared run identifier used for result folder name |
 | `SLO_RESULTS_DIR`                   | `/app/results` in Docker | Root directory for saved run results              |
 | `REF`                               | unknown                  | Label for metrics (with-retry / no-retry)         |

--- a/spring-ydb-retry/slo/playground/chaos-aggressive/compose.yaml
+++ b/spring-ydb-retry/slo/playground/chaos-aggressive/compose.yaml
@@ -290,7 +290,7 @@ services:
       SPRING_DATASOURCE_URL: jdbc:ydb:grpc://static-0:2135/Root/testdb
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: tech.ydb.jdbc.YdbDriver
       YDB_TRANSACTION_RETRY_ENABLED: "true"
-      YDB_TRANSACTION_RETRY_MAX_RETRIES: "10"
+      YDB_TRANSACTION_RETRY_MAX_ATTEMPTS: "10"
       REF: with-retry
       SLO_RUN_ID: ${SLO_RUN_ID:-}
       SLO_RESULTS_DIR: /app/results

--- a/spring-ydb-retry/slo/playground/chaos/compose.yaml
+++ b/spring-ydb-retry/slo/playground/chaos/compose.yaml
@@ -282,7 +282,7 @@ services:
       SPRING_DATASOURCE_URL: jdbc:ydb:grpc://static-0:2135/Root/testdb
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: tech.ydb.jdbc.YdbDriver
       YDB_TRANSACTION_RETRY_ENABLED: "true"
-      YDB_TRANSACTION_RETRY_MAX_RETRIES: "10"
+      YDB_TRANSACTION_RETRY_MAX_ATTEMPTS: "10"
       REF: with-retry
       SLO_RUN_ID: ${SLO_RUN_ID:-}
       SLO_RESULTS_DIR: /app/results

--- a/spring-ydb-retry/slo/pom.xml
+++ b/spring-ydb-retry/slo/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>tech.ydb</groupId>
             <artifactId>spring-ydb-retry</artifactId>
-            <version>0.9.0</version>
+            <version>0.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/spring-ydb-retry/slo/src/README.md
+++ b/spring-ydb-retry/slo/src/README.md
@@ -23,7 +23,7 @@ java -jar target/ydb-slo-workload-1.0.0-SNAPSHOT-exec.jar \
   --server.port=8081 \
   --spring.datasource.url=jdbc:ydb:grpc://localhost:2136/Root/testdb \
   --ydb.transaction.retry.enabled=true \
-  --ydb.transaction.retry.max-retries=10 \
+  --ydb.transaction.retry.max-attempts=10 \
   --slo.ref=with-retry
 
 # Without retry
@@ -76,7 +76,7 @@ All parameters are set via environment variables (or Spring Boot command-line ar
 | `SERVER_PORT`                       | `8080`                                       | HTTP port (Actuator endpoints)                         |
 | `SPRING_DATASOURCE_URL`             | `jdbc:ydb:grpc://localhost:2136/Root/testdb` | YDB JDBC URL                                           |
 | `YDB_TRANSACTION_RETRY_ENABLED`     | `true`                                       | Enable/disable retry                                   |
-| `YDB_TRANSACTION_RETRY_MAX_RETRIES` | `10`                                         | Max retry attempts                                     |
+| `YDB_TRANSACTION_RETRY_MAX_ATTEMPTS` | `10`                                        | Max total attempts (incl. initial execution)           |
 | `SLO_RUN_ID`                        | auto                                         | Shared run identifier used for the result folder name  |
 | `SLO_RESULTS_DIR`                   | `results`                                    | Root directory where per-run result folders are stored |
 

--- a/spring-ydb-retry/slo/src/main/java/tech/ydb/slo/SloResultWriter.java
+++ b/spring-ydb-retry/slo/src/main/java/tech/ydb/slo/SloResultWriter.java
@@ -120,7 +120,7 @@ public class SloResultWriter {
         builder.append("runTimeSeconds: ").append(config.getRunTimeSeconds()).append('\n');
         builder.append('\n');
         builder.append("retryEnabled: ").append(retryProperties.isEnabled()).append('\n');
-        builder.append("retryMaxRetries: ").append(retryProperties.getMaxRetries()).append('\n');
+        builder.append("retryMaxAttempts: ").append(retryProperties.getMaxAttempts()).append('\n');
         builder.append("retrySlowBackoffBaseMs: ")
                 .append(retryProperties.getSlowBackoffBaseMs())
                 .append('\n');

--- a/spring-ydb-retry/slo/src/main/resources/application.properties
+++ b/spring-ydb-retry/slo/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driver-class-name=tech.ydb.jdbc.YdbDriver
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
 ydb.transaction.retry.enabled=${YDB_TRANSACTION_RETRY_ENABLED:true}
-ydb.transaction.retry.max-retries=${YDB_TRANSACTION_RETRY_MAX_RETRIES:10}
+ydb.transaction.retry.max-attempts=${YDB_TRANSACTION_RETRY_MAX_ATTEMPTS:10}
 
 slo.read-rps=${SLO_READ_RPS:100}
 slo.write-rps=${SLO_WRITE_RPS:100}

--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryPolicy.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryPolicy.java
@@ -75,7 +75,10 @@ public final class YdbRetryPolicy {
      */
     public static OptionalLong getNextRetryDelayMs(
             int vendorCode, int attempt, YdbRetryPolicyConfig config, boolean idempotent) {
-        if (attempt >= config.getMaxRetries()) {
+        // {@code attempt} is the zero-based index of the attempt that has just failed, so the next
+        // attempt is allowed only while we stay within the total {@code maxAttempts} budget
+        // (which counts the initial execution).
+        if (attempt + 1 >= config.getMaxAttempts()) {
             return OptionalLong.empty();
         }
         if (vendorCode == 0) {

--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryPolicyConfig.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryPolicyConfig.java
@@ -14,14 +14,14 @@ import org.springframework.lang.Nullable;
  */
 public final class YdbRetryPolicyConfig {
     public static final boolean DEFAULT_ENABLED = true;
-    public static final int DEFAULT_MAX_RETRIES = 10;
+    public static final int DEFAULT_MAX_ATTEMPTS = 10;
     public static final int DEFAULT_SLOW_BACKOFF_BASE_MS = 50;
     public static final int DEFAULT_FAST_BACKOFF_BASE_MS = 5;
     public static final int DEFAULT_SLOW_CAP_BACKOFF_MS = 5_000;
     public static final int DEFAULT_FAST_CAP_BACKOFF_MS = 500;
 
     private final boolean enabled;
-    private final int maxRetries;
+    private final int maxAttempts;
     private final int slowBackoffBaseMs;
     private final int fastBackoffBaseMs;
     private final int slowCapBackoffMs;
@@ -32,7 +32,7 @@ public final class YdbRetryPolicyConfig {
     public YdbRetryPolicyConfig() {
         this(
                 DEFAULT_ENABLED,
-                DEFAULT_MAX_RETRIES,
+                DEFAULT_MAX_ATTEMPTS,
                 DEFAULT_SLOW_BACKOFF_BASE_MS,
                 DEFAULT_FAST_BACKOFF_BASE_MS,
                 DEFAULT_SLOW_CAP_BACKOFF_MS,
@@ -41,13 +41,13 @@ public final class YdbRetryPolicyConfig {
 
     public YdbRetryPolicyConfig(
             boolean enabled,
-            int maxRetries,
+            int maxAttempts,
             int slowBackoffBaseMs,
             int fastBackoffBaseMs,
             int slowCapBackoffMs,
             int fastCapBackoffMs) {
-        if (maxRetries < 1) {
-            throw new IllegalArgumentException("maxRetries must be >= 1");
+        if (maxAttempts < 0) {
+            throw new IllegalArgumentException("maxAttempts must be >= 0");
         }
         if (slowBackoffBaseMs < 0
                 || fastBackoffBaseMs < 0
@@ -56,7 +56,7 @@ public final class YdbRetryPolicyConfig {
             throw new IllegalArgumentException("backoff values must be >= 0");
         }
         this.enabled = enabled;
-        this.maxRetries = maxRetries;
+        this.maxAttempts = maxAttempts;
         this.slowBackoffBaseMs = slowBackoffBaseMs;
         this.fastBackoffBaseMs = fastBackoffBaseMs;
         this.slowCapBackoffMs = slowCapBackoffMs;
@@ -69,8 +69,8 @@ public final class YdbRetryPolicyConfig {
         return enabled;
     }
 
-    public int getMaxRetries() {
-        return maxRetries;
+    public int getMaxAttempts() {
+        return maxAttempts;
     }
 
     public int getSlowBackoffBaseMs() {
@@ -103,36 +103,26 @@ public final class YdbRetryPolicyConfig {
         }
         return new YdbRetryPolicyConfig(
                 enabled && transactionPolicy.enabled(),
-                mergeMaxRetries(transactionPolicy.maxRetries(), maxRetries),
-                mergeNonNegativeInt(
+                mergeOverride("maxAttempts", transactionPolicy.maxAttempts(), maxAttempts),
+                mergeOverride(
                         "slowBackoffBaseMs", transactionPolicy.slowBackoffBaseMs(), slowBackoffBaseMs),
-                mergeNonNegativeInt(
+                mergeOverride(
                         "fastBackoffBaseMs", transactionPolicy.fastBackoffBaseMs(), fastBackoffBaseMs),
-                mergeNonNegativeInt(
+                mergeOverride(
                         "slowCapBackoffMs", transactionPolicy.slowCapBackoffMs(), slowCapBackoffMs),
-                mergeNonNegativeInt(
+                mergeOverride(
                         "fastCapBackoffMs", transactionPolicy.fastCapBackoffMs(), fastCapBackoffMs));
     }
 
-    private static int mergeMaxRetries(int candidate, int fallback) {
-        return switch (candidate) {
-            case -1 -> fallback;
-            case 0 -> throw new IllegalArgumentException(
-                    "maxRetries must not be 0; use enabled = false to disable retry");
-            default -> {
-                if (candidate < -1) {
-                    throw new IllegalArgumentException("maxRetries must be -1 or >= 1");
-                }
-                yield candidate;
-            }
-        };
-    }
-
-    private static int mergeNonNegativeInt(String name, int candidate, int fallback) {
-        if (candidate < -1) {
-            throw new IllegalArgumentException(String.format("%s is invalid", name));
+    /**
+     * Resolves a per-method override against the global value: {@code 0} inherits the global value,
+     * a positive value overrides it, and a negative value is rejected.
+     */
+    private static int mergeOverride(String name, int candidate, int fallback) {
+        if (candidate < 0) {
+            throw new IllegalArgumentException(name + " must be >= 0");
         }
-        return candidate == -1 ? fallback : candidate;
+        return candidate == 0 ? fallback : candidate;
     }
 
     /**

--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryProperties.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbRetryProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class YdbRetryProperties {
 
     private boolean enabled = YdbRetryPolicyConfig.DEFAULT_ENABLED;
-    private int maxRetries = YdbRetryPolicyConfig.DEFAULT_MAX_RETRIES;
+    private int maxAttempts = YdbRetryPolicyConfig.DEFAULT_MAX_ATTEMPTS;
     private int slowBackoffBaseMs = YdbRetryPolicyConfig.DEFAULT_SLOW_BACKOFF_BASE_MS;
     private int fastBackoffBaseMs = YdbRetryPolicyConfig.DEFAULT_FAST_BACKOFF_BASE_MS;
     private int slowCapBackoffMs = YdbRetryPolicyConfig.DEFAULT_SLOW_CAP_BACKOFF_MS;
@@ -20,12 +20,12 @@ public class YdbRetryProperties {
         this.enabled = enabled;
     }
 
-    public int getMaxRetries() {
-        return maxRetries;
+    public int getMaxAttempts() {
+        return maxAttempts;
     }
 
-    public void setMaxRetries(int maxRetries) {
-        this.maxRetries = maxRetries;
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
     }
 
     public int getSlowBackoffBaseMs() {
@@ -63,7 +63,7 @@ public class YdbRetryProperties {
     public YdbRetryPolicyConfig toConfig() {
         return new YdbRetryPolicyConfig(
                 enabled,
-                maxRetries,
+                maxAttempts,
                 slowBackoffBaseMs,
                 fastBackoffBaseMs,
                 slowCapBackoffMs,

--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactionInterceptor.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactionInterceptor.java
@@ -22,10 +22,6 @@ public class YdbTransactionInterceptor extends TransactionInterceptor {
     private final YdbRetryPolicyConfig retryConfig;
     private final BackoffSleeper backoffSleeper;
 
-    public YdbTransactionInterceptor() {
-        this(new YdbRetryPolicyConfig(), Thread::sleep);
-    }
-
     YdbTransactionInterceptor(YdbRetryPolicyConfig retryConfig, BackoffSleeper backoffSleeper) {
         this.retryConfig = retryConfig;
         this.backoffSleeper = backoffSleeper;

--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactional.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactional.java
@@ -70,36 +70,41 @@ public @interface YdbTransactional {
     boolean enabled() default true;
 
     /**
-     * Specifies the maximum number of retry attempts after the initial failed execution.
-     * The annotated method may be executed up to {@code maxRetries + 1} times in total.
-     * Use {@code -1} to inherit the value from the global retry configuration.
-     * A value of {@code 0} is not supported; use {@code enabled() = false} to disable retry.
+     * Specifies the maximum total number of attempts, counting the initial execution.
+     * For example, {@code maxAttempts = 3} allows the initial attempt plus up to two retries,
+     * while {@code maxAttempts = 1} executes the method exactly once without retries.
+     * Use {@code 0} to inherit the value from the global retry configuration.
+     * Negative values are not allowed.
      */
-    int maxRetries() default -1;
+    int maxAttempts() default 0;
 
     /**
      * Overrides the base delay in milliseconds for the slow backoff strategy.
-     * Use {@code -1} to inherit the value from the global retry configuration.
+     * Use {@code 0} to inherit the value from the global retry configuration.
+     * Negative values are not allowed.
      */
-    int slowBackoffBaseMs() default -1;
+    int slowBackoffBaseMs() default 0;
 
     /**
      * Overrides the base delay in milliseconds for the fast backoff strategy.
-     * Use {@code -1} to inherit the value from the global retry configuration.
+     * Use {@code 0} to inherit the value from the global retry configuration.
+     * Negative values are not allowed.
      */
-    int fastBackoffBaseMs() default -1;
+    int fastBackoffBaseMs() default 0;
 
     /**
      * Overrides the maximum delay in milliseconds for the slow backoff strategy.
-     * Use {@code -1} to inherit the value from the global retry configuration.
+     * Use {@code 0} to inherit the value from the global retry configuration.
+     * Negative values are not allowed.
      */
-    int slowCapBackoffMs() default -1;
+    int slowCapBackoffMs() default 0;
 
     /**
      * Overrides the maximum delay in milliseconds for the fast backoff strategy.
-     * Use {@code -1} to inherit the value from the global retry configuration.
+     * Use {@code 0} to inherit the value from the global retry configuration.
+     * Negative values are not allowed.
      */
-    int fastCapBackoffMs() default -1;
+    int fastCapBackoffMs() default 0;
 
     /**
      * Marks the transactional method as idempotent for YDB retries.

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/InterceptorTestSupport.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/InterceptorTestSupport.java
@@ -22,15 +22,15 @@ abstract class InterceptorTestSupport {
     }
 
     static TestableInterceptor interceptorWithConfig(
-            boolean enabled, int maxRetries, int slowBase, int fastBase, int slowCap, int fastCap) {
+            boolean enabled, int maxAttempts, int slowBase, int fastBase, int slowCap, int fastCap) {
         return interceptorWithSleeper(
-                enabled, maxRetries, slowBase, fastBase, slowCap, fastCap, delay -> {
+                enabled, maxAttempts, slowBase, fastBase, slowCap, fastCap, delay -> {
                 });
     }
 
     static TestableInterceptor interceptorWithSleeper(
             boolean enabled,
-            int maxRetries,
+            int maxAttempts,
             int slowBase,
             int fastBase,
             int slowCap,
@@ -38,7 +38,7 @@ abstract class InterceptorTestSupport {
             BackoffSleeper sleeper) {
         TestableInterceptor interceptor =
                 new TestableInterceptor(
-                        new YdbRetryPolicyConfig(enabled, maxRetries, slowBase, fastBase, slowCap, fastCap),
+                        new YdbRetryPolicyConfig(enabled, maxAttempts, slowBase, fastBase, slowCap, fastCap),
                         sleeper);
         interceptor.setTransactionAttributeSource(new AnnotationTransactionAttributeSource());
         return interceptor;
@@ -123,27 +123,27 @@ abstract class InterceptorTestSupport {
     }
 
     static class YdbTransactionalTestService {
-        @YdbTransactional(maxRetries = 2)
+        @YdbTransactional(maxAttempts = 3)
         public String ydbCustomRetry() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 5)
+        @YdbTransactional(maxAttempts = 6)
         public String ydbRequiredRetry() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 2, propagation = Propagation.REQUIRES_NEW)
+        @YdbTransactional(maxAttempts = 3, propagation = Propagation.REQUIRES_NEW)
         public String ydbRequiresNewRetry() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 3, propagation = Propagation.NESTED)
+        @YdbTransactional(maxAttempts = 4, propagation = Propagation.NESTED)
         public String ydbNestedRetry() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 3, propagation = Propagation.NOT_SUPPORTED)
+        @YdbTransactional(maxAttempts = 4, propagation = Propagation.NOT_SUPPORTED)
         public String ydbNotSupportedRetry() {
             return "ok";
         }
@@ -174,7 +174,7 @@ abstract class InterceptorTestSupport {
         }
 
         @YdbTransactional(
-                maxRetries = 100,
+                maxAttempts = 100,
                 slowBackoffBaseMs = 200,
                 fastBackoffBaseMs = 10,
                 slowCapBackoffMs = 10000,
@@ -183,22 +183,22 @@ abstract class InterceptorTestSupport {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = -2)
-        public String ydbNegativeMaxRetries() {
+        @YdbTransactional(maxAttempts = -2)
+        public String ydbNegativeMaxAttempts() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 0)
-        public String ydbZeroMaxRetries() {
+        @YdbTransactional(maxAttempts = 0)
+        public String ydbZeroMaxAttempts() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 5, idempotent = true)
+        @YdbTransactional(maxAttempts = 6, idempotent = true)
         public String ydbIdempotentRetry() {
             return "ok";
         }
 
-        @YdbTransactional(maxRetries = 3)
+        @YdbTransactional(maxAttempts = 4)
         public String ydbNonIdempotentRetry() {
             return "ok";
         }

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/NestedYdbTransactionalRetryTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/NestedYdbTransactionalRetryTest.java
@@ -98,13 +98,13 @@ class NestedYdbTransactionalRetryTest {
             this.self = self;
         }
 
-        @YdbTransactional(maxRetries = 5)
+        @YdbTransactional(maxAttempts = 6)
         public void outer() {
             outerCount.incrementAndGet();
             self.inner();
         }
 
-        @YdbTransactional(maxRetries = 5)
+        @YdbTransactional(maxAttempts = 6)
         public void inner() {
             innerCount.incrementAndGet();
             if (innerCount.get() == 1) {
@@ -115,13 +115,13 @@ class NestedYdbTransactionalRetryTest {
             }
         }
 
-        @YdbTransactional(maxRetries = 5)
+        @YdbTransactional(maxAttempts = 6)
         public void outerWithFailingInner() {
             outerCount.incrementAndGet();
             self.failingInner();
         }
 
-        @YdbTransactional(maxRetries = 5)
+        @YdbTransactional(maxAttempts = 6)
         public void failingInner() {
             innerCount.incrementAndGet();
             throw new ConfigurableInnerException();

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/RetryStartsFreshTransactionTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/RetryStartsFreshTransactionTest.java
@@ -60,7 +60,7 @@ class RetryStartsFreshTransactionTest extends InterceptorTestSupport {
 
         assertThrows(ConfigurableStatusException.class, () -> interceptor.invoke(invocation));
 
-        assertEquals(3, txManager.beginCount(), "max-retries + 1 attempts must each begin a tx");
+        assertEquals(3, txManager.beginCount(), "every attempt up to maxAttempts must begin a tx");
         assertEquals(3, txManager.rollbackCount(), "all three attempts must roll back");
         assertEquals(0, txManager.commitCount(), "nothing must be committed");
     }
@@ -96,9 +96,9 @@ class RetryStartsFreshTransactionTest extends InterceptorTestSupport {
     }
 
     private static YdbTransactionInterceptor newInterceptor(
-            PlatformTransactionManager txManager, int maxRetries) {
+            PlatformTransactionManager txManager, int maxAttempts) {
         YdbTransactionInterceptor interceptor = new YdbTransactionInterceptor(
-                new YdbRetryPolicyConfig(true, maxRetries, 0, 0, 0, 0), delay -> {
+                new YdbRetryPolicyConfig(true, maxAttempts, 0, 0, 0, 0), delay -> {
                 });
         interceptor.setTransactionAttributeSource(new AnnotationTransactionAttributeSource());
         interceptor.setTransactionManager(txManager);

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/SqlExceptionStatusExtractionTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/SqlExceptionStatusExtractionTest.java
@@ -19,7 +19,7 @@ class SqlExceptionStatusExtractionTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryWhenSqlExceptionDirectlyCarriesRetryableStatus() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(plainSqlException(BAD_SESSION.getCode()), "ok");
 
         Object result = interceptor.invoke(invocationFor("regularTx"));
@@ -30,7 +30,7 @@ class SqlExceptionStatusExtractionTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryWhenSqlExceptionIsBuriedInSpringDataAccessWrapper() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         DataIntegrityViolationException wrapper = new DataIntegrityViolationException(
                 "wrapped", plainSqlException(ABORTED.getCode()));
         interceptor.enqueueOutcome(wrapper, "ok");
@@ -43,7 +43,7 @@ class SqlExceptionStatusExtractionTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenSqlExceptionHasNonRetryableStatus() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(plainSqlException(SCHEME_ERROR.getCode()));
 
         SQLException thrown =
@@ -55,7 +55,7 @@ class SqlExceptionStatusExtractionTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenSqlExceptionHasZeroVendorCode() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new SQLException("non-ydb driver", null, 0));
 
         assertThrows(SQLException.class, () -> interceptor.invoke(invocationFor("regularTx")));
@@ -64,7 +64,7 @@ class SqlExceptionStatusExtractionTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenSqlExceptionHasUnknownVendorCode() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new SQLException("some-other-driver", null, 12345));
 
         assertThrows(SQLException.class, () -> interceptor.invoke(invocationFor("regularTx")));

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/TransactionPropagationRetryTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/TransactionPropagationRetryTest.java
@@ -14,7 +14,7 @@ class TransactionPropagationRetryTest extends InterceptorTestSupport {
     void shouldDisableRetryWhenParticipatingInOuterTransaction() {
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new IllegalStateException("no retry expected"));
 
         assertThrows(
@@ -26,7 +26,7 @@ class TransactionPropagationRetryTest extends InterceptorTestSupport {
     void shouldRetryWithRequiresNewInsideOuterTransaction() throws Throwable {
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbRequiresNewRetry"));
@@ -39,7 +39,7 @@ class TransactionPropagationRetryTest extends InterceptorTestSupport {
     void shouldDisableRetryWithNestedPropagationInsideOuterTransaction() {
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(ABORTED));
 
         assertThrows(
@@ -52,7 +52,7 @@ class TransactionPropagationRetryTest extends InterceptorTestSupport {
     void shouldRetryWithNotSupportedPropagationInsideOuterTransaction() throws Throwable {
         TransactionSynchronizationManager.setActualTransactionActive(true);
 
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbNotSupportedRetry"));

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/TransactionalDefaultRetryTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/TransactionalDefaultRetryTest.java
@@ -18,7 +18,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryWithDefaultConfigUntilSuccess() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         Object result = interceptor.invoke(invocationFor("regularTx"));
@@ -30,7 +30,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldExhaustDefaultMaxRetriesAndPropagateLastException() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(BAD_SESSION),
                 new ConfigurableStatusException(ABORTED),
@@ -45,7 +45,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldPropagateNonRetryableExceptionImmediately() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(UNAUTHORIZED));
 
         ConfigurableStatusException exception =
@@ -60,7 +60,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryNonYdbRuntimeException() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new IllegalStateException("not ydb"));
 
         IllegalStateException exception =
@@ -74,7 +74,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldImmediatelyPropagateJavaError() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new OutOfMemoryError("test oom"));
 
         assertThrows(OutOfMemoryError.class, () -> interceptor.invoke(invocationFor("regularTx")));
@@ -83,7 +83,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryWhenYdbStatusExtractedFromExceptionChain() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new RuntimeException("wrapped", new ConfigurableStatusException(BAD_SESSION)), "ok");
 
@@ -96,7 +96,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
     @Test
     void shouldCallSleeperWithBackoffDelay() throws Throwable {
         List<Long> delays = new ArrayList<>();
-        TestableInterceptor interceptor = interceptorWithSleeper(true, 5, 0, 0, 0, 0, delays::add);
+        TestableInterceptor interceptor = interceptorWithSleeper(true, 6, 0, 0, 0, 0, delays::add);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(ABORTED), new ConfigurableStatusException(ABORTED), "ok");
 
@@ -114,7 +114,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
     void shouldUseZeroDelayForBadSession() throws Throwable {
         List<Long> delays = new ArrayList<>();
         TestableInterceptor interceptor =
-                interceptorWithSleeper(true, 5, 100, 50, 1000, 500, delays::add);
+                interceptorWithSleeper(true, 6, 100, 50, 1000, 500, delays::add);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         Object result = interceptor.invoke(invocationFor("regularTx"));
@@ -131,7 +131,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
         TestableInterceptor interceptor =
                 interceptorWithSleeper(
                         true,
-                        3,
+                        4,
                         0,
                         0,
                         0,
@@ -157,7 +157,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryClientInternalErrorForTransactionalMethod() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_INTERNAL_ERROR), "ok");
 
         ConfigurableStatusException exception =
@@ -171,7 +171,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryTimeoutForTransactionalMethodWhenDefaultConfigNotIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TIMEOUT));
 
         ConfigurableStatusException exception =
@@ -185,7 +185,7 @@ class TransactionalDefaultRetryTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenDisabledInConfig() {
-        TestableInterceptor interceptor = interceptorWithConfig(false, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(false, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         ConfigurableStatusException exception =

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbRetryPolicyConfigTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbRetryPolicyConfigTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_FAST_BACKOFF_BASE_MS;
 import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_FAST_CAP_BACKOFF_MS;
-import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_MAX_RETRIES;
+import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_MAX_ATTEMPTS;
 import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_SLOW_BACKOFF_BASE_MS;
 import static tech.ydb.retry.YdbRetryPolicyConfig.DEFAULT_SLOW_CAP_BACKOFF_MS;
 
@@ -21,7 +21,7 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
     void defaultConstructorShouldSetDefaultValues() {
         YdbRetryPolicyConfig config = new YdbRetryPolicyConfig();
 
-        assertEquals(DEFAULT_MAX_RETRIES, config.getMaxRetries());
+        assertEquals(DEFAULT_MAX_ATTEMPTS, config.getMaxAttempts());
         assertEquals(DEFAULT_SLOW_BACKOFF_BASE_MS, config.getSlowBackoffBaseMs());
         assertEquals(DEFAULT_FAST_BACKOFF_BASE_MS, config.getFastBackoffBaseMs());
         assertEquals(DEFAULT_SLOW_CAP_BACKOFF_MS, config.getSlowCapBackoffMs());
@@ -32,7 +32,7 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
     void customConstructorShouldSetValues() {
         YdbRetryPolicyConfig config = new YdbRetryPolicyConfig(true, 5, 100, 20, 2000, 300);
 
-        assertEquals(5, config.getMaxRetries());
+        assertEquals(5, config.getMaxAttempts());
         assertEquals(100, config.getSlowBackoffBaseMs());
         assertEquals(20, config.getFastBackoffBaseMs());
         assertEquals(2000, config.getSlowCapBackoffMs());
@@ -40,13 +40,13 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
     }
 
     @Test
-    void shouldThrowWhenMaxRetriesIsZero() {
-        assertThrows(
-                IllegalArgumentException.class, () -> new YdbRetryPolicyConfig(true, 0, 0, 0, 0, 0));
+    void shouldAcceptZeroMaxAttempts() {
+        YdbRetryPolicyConfig config = new YdbRetryPolicyConfig(true, 0, 0, 0, 0, 0);
+        assertEquals(0, config.getMaxAttempts());
     }
 
     @Test
-    void shouldThrowWhenMaxRetriesIsNegative() {
+    void shouldThrowWhenMaxAttemptsIsNegative() {
         assertThrows(
                 IllegalArgumentException.class, () -> new YdbRetryPolicyConfig(true, -1, 0, 0, 0, 0));
     }
@@ -91,7 +91,7 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
 
         YdbRetryPolicyConfig merged = original.merge(annotation);
 
-        assertEquals(5, merged.getMaxRetries());
+        assertEquals(5, merged.getMaxAttempts());
         assertEquals(100, merged.getSlowBackoffBaseMs());
         assertEquals(20, merged.getFastBackoffBaseMs());
         assertEquals(2000, merged.getSlowCapBackoffMs());
@@ -108,7 +108,7 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
 
         YdbRetryPolicyConfig merged = original.merge(annotation);
 
-        assertEquals(100, merged.getMaxRetries());
+        assertEquals(100, merged.getMaxAttempts());
         assertEquals(200, merged.getSlowBackoffBaseMs());
         assertEquals(10, merged.getFastBackoffBaseMs());
         assertEquals(10000, merged.getSlowCapBackoffMs());
@@ -125,8 +125,8 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
 
         YdbRetryPolicyConfig merged = original.merge(annotation);
 
-        // only maxRetries should change
-        assertEquals(2, merged.getMaxRetries());
+        // only maxAttempts should change
+        assertEquals(3, merged.getMaxAttempts());
         assertEquals(100, merged.getSlowBackoffBaseMs());
         assertEquals(20, merged.getFastBackoffBaseMs());
         assertEquals(2000, merged.getSlowCapBackoffMs());
@@ -134,10 +134,10 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
     }
 
     @Test
-    void shouldThrowWhenYdbTransactionalMaxRetriesIsNegative() throws NoSuchMethodException {
+    void shouldThrowWhenYdbTransactionalMaxAttemptsIsNegative() throws NoSuchMethodException {
         YdbRetryPolicyConfig original = new YdbRetryPolicyConfig(true, 5, 100, 20, 2000, 300);
 
-        Method method = YdbTransactionalTestService.class.getMethod("ydbNegativeMaxRetries");
+        Method method = YdbTransactionalTestService.class.getMethod("ydbNegativeMaxAttempts");
         YdbTransactional annotation =
                 AnnotatedElementUtils.findMergedAnnotation(method, YdbTransactional.class);
 
@@ -145,18 +145,16 @@ class YdbRetryPolicyConfigTest extends InterceptorTestSupport {
     }
 
     @Test
-    void shouldRejectZeroMaxRetriesAtAnnotationMergeTime() throws NoSuchMethodException {
+    void shouldInheritGlobalMaxAttemptsWhenAnnotationIsZero() throws NoSuchMethodException {
         YdbRetryPolicyConfig original = new YdbRetryPolicyConfig(true, 5, 100, 20, 2000, 300);
 
-        Method method = YdbTransactionalTestService.class.getMethod("ydbZeroMaxRetries");
+        Method method = YdbTransactionalTestService.class.getMethod("ydbZeroMaxAttempts");
         YdbTransactional annotation =
                 AnnotatedElementUtils.findMergedAnnotation(method, YdbTransactional.class);
 
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> original.merge(annotation));
+        YdbRetryPolicyConfig merged = original.merge(annotation);
 
-        assertEquals(
-                "maxRetries must not be 0; use enabled = false to disable retry", exception.getMessage());
+        assertEquals(5, merged.getMaxAttempts());
     }
 
     @Test

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbRetryPolicyTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbRetryPolicyTest.java
@@ -92,8 +92,10 @@ class YdbRetryPolicyTest {
     @Test
     void shouldReturnEmptyWhenAttemptBudgetExhausted() {
         YdbRetryPolicyConfig config = new YdbRetryPolicyConfig(true, 2, 0, 0, 0, 0);
+        // maxAttempts counts the initial execution, so with budget=2 only the first
+        // failure (attempt=0) is allowed to schedule a retry; the second one exhausts the budget.
         assertTrue(YdbRetryPolicy.getNextRetryDelayMs(ABORTED, 0, config, false).isPresent());
-        assertTrue(YdbRetryPolicy.getNextRetryDelayMs(ABORTED, 1, config, false).isPresent());
+        assertTrue(YdbRetryPolicy.getNextRetryDelayMs(ABORTED, 1, config, false).isEmpty());
         assertTrue(YdbRetryPolicy.getNextRetryDelayMs(ABORTED, 2, config, false).isEmpty());
     }
 

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorFactoryTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorFactoryTest.java
@@ -33,7 +33,7 @@ class YdbTransactionInterceptorFactoryTest {
     void getObjectShouldUseRetryPropertiesConfig() {
         YdbRetryProperties properties = new YdbRetryProperties();
         properties.setEnabled(false);
-        properties.setMaxRetries(3);
+        properties.setMaxAttempts(3);
         YdbTransactionInterceptorFactory factory = new YdbTransactionInterceptorFactory();
         factory.setRetryProperties(properties);
         factory.setTransactionAttributeSource(new AnnotationTransactionAttributeSource());

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorInvocationTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorInvocationTest.java
@@ -13,7 +13,7 @@ class YdbTransactionInterceptorInvocationTest extends InterceptorTestSupport {
 
     @Test
     void shouldCloneProxyMethodInvocationForEachRetryAttempt() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
 
         Method method = methodOf("ydbCustomRetry");
         Object target = new YdbTransactionalTestService();

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorReplacerTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorReplacerTest.java
@@ -99,7 +99,7 @@ class YdbTransactionInterceptorReplacerTest {
         PlatformTransactionManager txManager = Mockito.mock(PlatformTransactionManager.class);
         YdbRetryProperties properties = new YdbRetryProperties();
         properties.setEnabled(false);
-        properties.setMaxRetries(3);
+        properties.setMaxAttempts(3);
         TransactionAttributeSource tas = new AnnotationTransactionAttributeSource();
 
         beanFactory.registerSingleton("transactionManager", txManager);

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionalConfigOverrideTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionalConfigOverrideTest.java
@@ -23,7 +23,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldOverrideMaxRetriesFromAnnotation() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(ABORTED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbCustomRetry"));
@@ -35,7 +35,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldUseConfigMaxRetriesWhenAnnotationNotSet() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         Object result = interceptor.invoke(invocationFor("defaultRetry"));
@@ -47,7 +47,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldExhaustAnnotatedMaxRetriesAndPropagate() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(SESSION_BUSY),
                 new ConfigurableStatusException(OVERLOADED),
@@ -65,7 +65,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldUseAnnotatedMaxRetriesWhenLowerThanConfig() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(OVERLOADED),
                 new ConfigurableStatusException(BAD_SESSION),
@@ -83,7 +83,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldUseAnnotatedMaxRetriesWhenHigherThanConfig() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(BAD_SESSION),
                 new ConfigurableStatusException(SESSION_BUSY),
@@ -99,7 +99,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryDifferentStatusCodesAcrossRetries() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(ABORTED),
                 new ConfigurableStatusException(BAD_SESSION),
@@ -113,7 +113,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryClientCancelledWhenNotIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_CANCELLED), "ok");
 
         ConfigurableStatusException exception =
@@ -127,7 +127,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryClientCancelledEvenWhenIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_CANCELLED), "ok");
 
         ConfigurableStatusException exception =
@@ -141,7 +141,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryClientInternalErrorEvenWhenIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_INTERNAL_ERROR), "ok");
 
         ConfigurableStatusException exception =
@@ -155,7 +155,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldUseInterfaceMethodYdbTransactionalOverrides() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 1, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 2, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TRANSPORT_UNAVAILABLE), "ok");
 
         Object result = interceptor.invoke(invocationFor(
@@ -168,7 +168,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryTransportUnavailableWhenNotIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TRANSPORT_UNAVAILABLE), "ok");
 
         ConfigurableStatusException exception =
@@ -182,7 +182,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryTransportUnavailableWhenIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TRANSPORT_UNAVAILABLE), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -193,7 +193,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryClientResourceExhaustedWhenNotIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_RESOURCE_EXHAUSTED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbNonIdempotentRetry"));
@@ -204,7 +204,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryClientResourceExhaustedWhenIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(CLIENT_RESOURCE_EXHAUSTED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -215,7 +215,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryTimeoutWhenIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TIMEOUT));
 
         ConfigurableStatusException exception =
@@ -229,7 +229,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetrySessionExpiredWhenNotIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(SESSION_EXPIRED));
 
         ConfigurableStatusException exception =
@@ -243,7 +243,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryAlwaysRetryableCodesWhenIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(ABORTED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -254,7 +254,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetryMixedStatusCodesWhenIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(ABORTED),
                 new ConfigurableStatusException(UNDETERMINED),
@@ -269,7 +269,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldRetrySessionExpiredWithZeroDelayWhenIdempotent() throws Throwable {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(SESSION_EXPIRED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -280,7 +280,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldStopAtIdempotentOnlyCodeWhenNotIdempotent() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 5, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 6, 0, 0, 0, 0);
         interceptor.enqueueOutcome(
                 new ConfigurableStatusException(BAD_SESSION), new ConfigurableStatusException(TIMEOUT));
 
@@ -297,7 +297,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
     void shouldNotReachDelayCalculatorForTimeoutWhenIdempotent() {
         List<Long> delays = new ArrayList<>();
         TestableInterceptor interceptor =
-                interceptorWithSleeper(true, 5, 100, 50, 1000, 500, delays::add);
+                interceptorWithSleeper(true, 6, 100, 50, 1000, 500, delays::add);
         interceptor.enqueueOutcome(new ConfigurableStatusException(TIMEOUT));
 
         assertThrows(
@@ -312,7 +312,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
     void shouldUseZeroDelayForSessionExpiredWhenIdempotent() throws Throwable {
         List<Long> delays = new ArrayList<>();
         TestableInterceptor interceptor =
-                interceptorWithSleeper(true, 5, 100, 50, 1000, 500, delays::add);
+                interceptorWithSleeper(true, 6, 100, 50, 1000, 500, delays::add);
         interceptor.enqueueOutcome(new ConfigurableStatusException(SESSION_EXPIRED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -326,7 +326,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
     void shouldUseFastBackoffForUndeterminedWhenIdempotent() throws Throwable {
         List<Long> delays = new ArrayList<>();
         TestableInterceptor interceptor =
-                interceptorWithSleeper(true, 5, 100, 50, 1000, 500, delays::add);
+                interceptorWithSleeper(true, 6, 100, 50, 1000, 500, delays::add);
         interceptor.enqueueOutcome(new ConfigurableStatusException(UNDETERMINED), "ok");
 
         interceptor.invoke(invocationFor("ydbIdempotentRetry"));
@@ -338,7 +338,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
     @Test
     void shouldDelayFirstOverloadedRetryUsingZeroBasedRetryIndex() throws Throwable {
         List<Long> delays = new ArrayList<>();
-        TestableInterceptor interceptor = interceptorWithSleeper(true, 5, 1, 1, 1, 1, delays::add);
+        TestableInterceptor interceptor = interceptorWithSleeper(true, 6, 1, 1, 1, 1, delays::add);
         interceptor.enqueueOutcome(new ConfigurableStatusException(OVERLOADED), "ok");
 
         Object result = interceptor.invoke(invocationFor("ydbCustomRetry"));
@@ -350,7 +350,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenMethodDisablesRetry() {
-        TestableInterceptor interceptor = interceptorWithConfig(true, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(true, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         ConfigurableStatusException exception =
@@ -364,7 +364,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
 
     @Test
     void shouldNotRetryWhenGlobalConfigDisablesRetryEvenIfMethodEnablesIt() {
-        TestableInterceptor interceptor = interceptorWithConfig(false, 3, 0, 0, 0, 0);
+        TestableInterceptor interceptor = interceptorWithConfig(false, 4, 0, 0, 0, 0);
         interceptor.enqueueOutcome(new ConfigurableStatusException(BAD_SESSION), "ok");
 
         ConfigurableStatusException exception =
@@ -377,7 +377,7 @@ class YdbTransactionalConfigOverrideTest extends InterceptorTestSupport {
     }
 
     interface InterfaceAnnotatedService {
-        @YdbTransactional(maxRetries = 2, idempotent = true)
+        @YdbTransactional(maxAttempts = 3, idempotent = true)
         String interfaceAnnotatedIdempotentRetry();
     }
 

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/CommitTransactionRetryTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/CommitTransactionRetryTest.java
@@ -13,6 +13,7 @@ import tech.ydb.retry.integration.app.UserService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = UserApplication.class)
 @ActiveProfiles({"enabled", "ydb"})
@@ -28,6 +29,13 @@ class CommitTransactionRetryTest extends YdbDockerTest {
         userService.deleteAll();
     }
 
+    /**
+     * When the first CommitTransaction RPC returns a retryable status, the retry must (a) re-issue
+     * an ExecuteQuery for the INSERT against a fresh transaction and (b) issue a second
+     * CommitTransaction RPC. Both gRPC counters are observed via the deterministic error channel.
+     * Without (a) the data would never reach the new tx; without (b) Spring would silently swallow
+     * a failed commit.
+     */
     @ParameterizedTest(name = "CommitTransaction")
     @EnumSource(
             value = StatusCode.class,
@@ -35,10 +43,18 @@ class CommitTransactionRetryTest extends YdbDockerTest {
     void shouldRecoverFromRetryableCommitError(StatusCode code) {
         DeterministicErrorChannel.configure().onError("commitTransaction", 1, code);
 
-        userService.save(createUser(1L, "user1", "first1", "last1"));
+        User user = createUser(1L, "user1", "first1", "last1");
+        userService.save(user);
 
-        assertEquals(2, DeterministicErrorChannel.getCallCount("commitTransaction"));
-        assertNotNull(userService.findById(1L));
+        assertEquals(2, DeterministicErrorChannel.getCallCount("commitTransaction"),
+                "commit must be attempted twice: first attempt fails with " + code
+                        + ", retry must honestly invoke CommitTransaction again");
+        assertTrue(DeterministicErrorChannel.getCallCount("executeQuery") >= 2,
+                "INSERT must be re-executed against a fresh transaction on retry");
+
+        User persisted = userService.findById(user.getId());
+        assertNotNull(persisted, "user must end up persisted by the successful retry commit");
+        assertEquals(user.getUsername(), persisted.getUsername());
     }
 
     @ParameterizedTest(name = "CommitTransaction")

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/HappyPathIntegrationTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/HappyPathIntegrationTest.java
@@ -50,7 +50,7 @@ class HappyPathIntegrationTest extends YdbDockerTest {
     @Test
     void shouldSaveWithMaxRetries3() {
         User user = createUser(3L, "user3", "first", "last");
-        userService.saveWithMaxRetries3(user);
+        userService.saveWithMaxAttempts4(user);
 
         User found = userService.findById(3L);
         assertNotNull(found);

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/MaxRetriesExhaustedTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/MaxRetriesExhaustedTest.java
@@ -38,7 +38,7 @@ class MaxRetriesExhaustedTest extends YdbDockerTest {
 
         assertThrows(
                 Exception.class,
-                () -> userService.saveWithMaxRetries3(createUser(1L, "user1", "first1", "last1")));
+                () -> userService.saveWithMaxAttempts4(createUser(1L, "user1", "first1", "last1")));
         assertEquals(4, DeterministicErrorChannel.getCallCount("executeQuery"));
     }
 
@@ -48,7 +48,7 @@ class MaxRetriesExhaustedTest extends YdbDockerTest {
                 .onError("executeQuery", 1, StatusCode.ABORTED)
                 .onError("executeQuery", 2, StatusCode.ABORTED);
 
-        userService.saveWithMaxRetries3(createUser(2L, "user2", "first2", "last2"));
+        userService.saveWithMaxAttempts4(createUser(2L, "user2", "first2", "last2"));
 
         assertEquals(3, DeterministicErrorChannel.getCallCount("executeQuery"));
         assertNotNull(userService.findById(2L));

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/NonRetryableCommitIntegrationTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/NonRetryableCommitIntegrationTest.java
@@ -51,7 +51,7 @@ class NonRetryableCommitIntegrationTest extends YdbDockerTest {
 
         assertThrows(
                 Exception.class,
-                () -> userService.saveWithMaxRetries3(createUser(2L, "user2", "first2", "last2")));
+                () -> userService.saveWithMaxAttempts4(createUser(2L, "user2", "first2", "last2")));
         assertEquals(1, DeterministicErrorChannel.getCallCount("commitTransaction"));
         assertNull(userService.findById(2L));
     }

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/app/UserService.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/integration/app/UserService.java
@@ -23,8 +23,8 @@ public class UserService {
         userRepository.save(user);
     }
 
-    @YdbTransactional(maxRetries = 3)
-    public void saveWithMaxRetries3(User user) {
+    @YdbTransactional(maxAttempts = 4)
+    public void saveWithMaxAttempts4(User user) {
         userRepository.save(user);
     }
 
@@ -33,7 +33,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    @YdbTransactional(maxRetries = 50, idempotent = true)
+    @YdbTransactional(maxAttempts = 51, idempotent = true)
     public void updateFirstname(Long id, String firstname) {
         userRepository.findById(id);
         userRepository.updateFirstnameById(id, firstname);

--- a/spring-ydb-retry/src/test/resources/application-enabled.properties
+++ b/spring-ydb-retry/src/test/resources/application-enabled.properties
@@ -2,7 +2,7 @@ spring.datasource.hikari.maximum-pool-size=5
 spring.datasource.hikari.connection-timeout=10000
 
 ydb.transaction.retry.enabled=true
-ydb.transaction.retry.max-retries=5
+ydb.transaction.retry.max-attempts=5
 ydb.transaction.retry.slow-backoff-base-ms=50
 ydb.transaction.retry.fast-backoff-base-ms=5
 ydb.transaction.retry.slow-cap-backoff-ms=5000


### PR DESCRIPTION
## Summary

Introduces the `spring-ydb-retry` module as a standalone, releasable Maven artifact and refines its retry API.

- Pulls the module up to the repository root as an independent module (`tech.ydb:spring-ydb-retry`) with its own CI/publish workflows.
- Renames the retry setting `maxRetries` → `maxAttempts` with Spring Retry semantics: `maxAttempts` counts the **total** number of attempts including the initial execution (`maxAttempts = 3` → initial attempt + up to 2 retries, `maxAttempts = 1` → single run without retries). The property `ydb.transaction.retry.max-retries` becomes `ydb.transaction.retry.max-attempts`.
- `@YdbTransactional` override attributes now use `0` (instead of `-1`) to inherit the global configuration value; negative values are rejected.
- Bumps the module version to `0.10.0`, updates `CHANGELOG.md`, and adds a Maven/CI/License version badge to the module README.

## Test plan

- [x] `mvn clean test` for the retry unit/interceptor test suite (94 tests, green)
- [ ] Integration tests (require Docker/YDB) — run in CI

Made with [Cursor](https://cursor.com)