### PR TITLE
Make YdbTransactionInterceptor wiring AOT-compatible

### DIFF
--- a/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactionInterceptorReplacer.java
+++ b/spring-ydb-retry/src/main/java/tech/ydb/retry/YdbTransactionInterceptorReplacer.java
@@ -4,11 +4,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.core.Ordered;
+import org.springframework.transaction.interceptor.TransactionAttributeSource;
 
 public class YdbTransactionInterceptorReplacer
         implements BeanDefinitionRegistryPostProcessor, Ordered {
@@ -51,8 +53,16 @@ public class YdbTransactionInterceptorReplacer
     private AbstractBeanDefinition buildYdbInterceptorBeanDefinition(BeanDefinition existingBd) {
         AbstractBeanDefinition newBd =
                 BeanDefinitionBuilder.genericBeanDefinition(YdbTransactionInterceptorFactory.class)
-                        .setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE)
                         .getBeanDefinition();
+
+        // Declare dependencies as explicit property references (resolved by type) rather than
+        // relying on AUTOWIRE_BY_TYPE. The legacy autowire modes are silently dropped by Spring's
+        // AOT engine, which freezes bean definitions into generated code; explicit property values
+        // are code-generated and therefore survive AOT.
+        newBd.getPropertyValues().addPropertyValue(
+                "retryProperties", new RuntimeBeanReference(YdbRetryProperties.class));
+        newBd.getPropertyValues().addPropertyValue(
+                "transactionAttributeSource", new RuntimeBeanReference(TransactionAttributeSource.class));
 
         copyBeanDefinitionMetadata(existingBd, newBd);
         return newBd;

--- a/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorReplacerTest.java
+++ b/spring-ydb-retry/src/test/java/tech/ydb/retry/YdbTransactionInterceptorReplacerTest.java
@@ -3,7 +3,9 @@ package tech.ydb.retry;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.beans.PropertyValue;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.AutowireCandidateQualifier;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -18,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,6 +89,40 @@ class YdbTransactionInterceptorReplacerTest {
                 beanFactory.getBeansOfType(TransactionInterceptor.class);
         assertEquals(1, interceptors.size());
         assertSame(bean, interceptors.get("transactionInterceptor"));
+    }
+
+    @Test
+    void shouldDeclareDependenciesAsExplicitPropertyReferences() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        BeanDefinition beanDefinition =
+                BeanDefinitionBuilder.genericBeanDefinition(TransactionInterceptor.class)
+                        .getBeanDefinition();
+        beanFactory.registerBeanDefinition("transactionInterceptor", beanDefinition);
+
+        YdbTransactionInterceptorReplacer pp = new YdbTransactionInterceptorReplacer();
+        pp.postProcessBeanDefinitionRegistry(beanFactory);
+
+        AbstractBeanDefinition replaced =
+                (AbstractBeanDefinition) beanFactory.getBeanDefinition("transactionInterceptor");
+
+        // Must not rely on the legacy autowire modes: they are dropped by Spring AOT.
+        assertEquals(AbstractBeanDefinition.AUTOWIRE_NO, replaced.getAutowireMode());
+
+        PropertyValue retryProperties =
+                replaced.getPropertyValues().getPropertyValue("retryProperties");
+        assertNotNull(retryProperties);
+        assertInstanceOf(RuntimeBeanReference.class, retryProperties.getValue());
+        assertEquals(
+                YdbRetryProperties.class,
+                ((RuntimeBeanReference) retryProperties.getValue()).getBeanType());
+
+        PropertyValue transactionAttributeSource =
+                replaced.getPropertyValues().getPropertyValue("transactionAttributeSource");
+        assertNotNull(transactionAttributeSource);
+        assertInstanceOf(RuntimeBeanReference.class, transactionAttributeSource.getValue());
+        assertEquals(
+                TransactionAttributeSource.class,
+                ((RuntimeBeanReference) transactionAttributeSource.getValue()).getBeanType());
     }
 
     @Test


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The replacer swapped Spring's `transactionInterceptor` bean for a YdbTransactionInterceptorFactory whose dependencies were supplied via setAutowireMode(AUTOWIRE_BY_TYPE). Spring's AOT engine runs the BeanDefinitionRegistryPostProcessor at build time and freezes the result into generated code, but it does not support the legacy autowire modes, so retryProperties/transactionAttributeSource were never injected. At runtime the factory's getObject() then failed with "retryProperties must be set...".

Issue Number: N/A

## What is the new behavior?

Declare the two dependencies as explicit RuntimeBeanReference property values (resolved by type) instead. Explicit property values are code-generated by AOT and therefore survive, while JIT behavior is unchanged. The factory and post-processor are otherwise untouched.