### PR TITLE
dev: prepare spring-ydb-retry 0.10.1 release

### DIFF
--- a/spring-ydb-retry/CHANGELOG.md
+++ b/spring-ydb-retry/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1 ##
+
+- Fixed `YdbTransactionInterceptor` wiring for Spring AOT by replacing legacy autowiring mode with explicit bean references.
+
 ## 0.10.0 ##
 
 - Renamed the `maxRetries` retry setting to `maxAttempts`, which now counts the total number of attempts including the initial execution (aligned with Spring Retry semantics). The `ydb.transaction.retry.max-retries` property is renamed to `ydb.transaction.retry.max-attempts`.

--- a/spring-ydb-retry/pom.xml
+++ b/spring-ydb-retry/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>tech.ydb</groupId>
     <artifactId>spring-ydb-retry</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>jar</packaging>
 
     <name>Spring YDB Retry</name>


### PR DESCRIPTION
## Summary
- bump `spring-ydb-retry` module version from `0.10.0` to `0.10.1`
- add `0.10.1` changelog entry describing the Spring AOT interceptor wiring fix
- keep release notes aligned with the AOT compatibility fix already merged to `main`

## Test plan
- [x] `cd spring-ydb-retry && mvn -Dtest=YdbTransactionInterceptorReplacerTest test`

Made with [Cursor](https://cursor.com)