### PR TITLE
fix(spring-data-jdbc): exclude composite id columns from UPDATE SET on YDB

### DIFF
--- a/spring-data-jdbc-ydb/pom.xml
+++ b/spring-data-jdbc-ydb/pom.xml
@@ -53,6 +53,10 @@
         <ydb.sdk.version>2.3.13</ydb.sdk.version>
         <ydb.jdbc.version>2.3.10</ydb.jdbc.version>
         <ydb.liquibase.version>1.1.1</ydb.liquibase.version>
+
+        <!-- composite (embedded) @Id support was added in Spring Data JDBC 4.0, so tests exercising it only
+             run under the spring-boot4 profile -->
+        <surefire.excludes>**/CompositeKeyUpdateTest.java</surefire.excludes>
     </properties>
 
     <dependencyManagement>
@@ -158,6 +162,9 @@
                     <environmentVariables>
                         <TESTCONTAINERS_REUSE_ENABLE>true</TESTCONTAINERS_REUSE_ENABLE>
                     </environmentVariables>
+                    <excludes>
+                        <exclude>${surefire.excludes}</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -182,6 +189,7 @@
             <id>spring-boot4</id>
             <properties>
                 <spring.version>4.0.3</spring.version>
+                <surefire.excludes>__none__</surefire.excludes>
             </properties>
             <dependencies>
                 <dependency>

--- a/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/core/convert/YdbColumns.java
+++ b/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/core/convert/YdbColumns.java
@@ -1,0 +1,71 @@
+package tech.ydb.data.core.convert;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Computes the set of id columns and updatable (non-id, writable, non-insert-only) columns for an entity,
+ * correctly propagating "is part of the id" into columns reached through a composite/embedded {@code @Id}.
+ * <p>
+ * This mirrors {@code org.springframework.data.jdbc.core.convert.SqlGenerator.Columns}, which has a known gap for
+ * composite ids: {@code initSimpleColumnName} checks {@code property.getOwner().isIdProperty(property)}, and for a
+ * property reached by recursing into an embedded id, the "owner" is the id wrapper type itself, which has no
+ * {@code @Id} field of its own - so none of the composite id's columns are recognized as id columns and all end up
+ * in the {@code UPDATE ... SET ...} clause. YDB rejects such statements with "Cannot update primary key column"
+ * (see YDBREQUESTS-8347, https://github.com/spring-projects/spring-data-relational/issues/2338).
+ */
+final class YdbColumns {
+
+    private final Set<SqlIdentifier> idColumns = new LinkedHashSet<>();
+    private final Set<SqlIdentifier> updatableColumns = new LinkedHashSet<>();
+
+    private YdbColumns() {
+    }
+
+    static YdbColumns resolve(RelationalPersistentEntity<?> entity, RelationalMappingContext context,
+            JdbcConverter converter) {
+
+        YdbColumns columns = new YdbColumns();
+        columns.collect(entity, context, converter, "", false);
+        return columns;
+    }
+
+    Set<SqlIdentifier> getIdColumns() {
+        return idColumns;
+    }
+
+    Set<SqlIdentifier> getUpdatableColumns() {
+        return updatableColumns;
+    }
+
+    private void collect(RelationalPersistentEntity<?> entity, RelationalMappingContext context,
+            JdbcConverter converter, String prefix, boolean withinId) {
+
+        entity.doWithAll(property -> {
+
+            boolean propertyIsId = withinId || entity.isIdProperty(property);
+
+            if (!property.isEntity()) {
+
+                SqlIdentifier columnName = property.getColumnName().transform(prefix::concat);
+
+                if (propertyIsId) {
+                    idColumns.add(columnName);
+                } else if (property.isWritable() && !property.isInsertOnly()) {
+                    updatableColumns.add(columnName);
+                }
+            } else if (property.isEmbedded()) {
+
+                RelationalPersistentEntity<?> embeddedEntity = context
+                        .getRequiredPersistentEntity(converter.getColumnType(property));
+
+                collect(embeddedEntity, context, converter, prefix + property.getEmbeddedPrefix(), propertyIsId);
+            }
+        });
+    }
+}

--- a/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/core/convert/YdbDataAccessStrategy.java
+++ b/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/core/convert/YdbDataAccessStrategy.java
@@ -1,0 +1,214 @@
+package tech.ydb.data.core.convert;
+
+import java.sql.SQLType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DelegatingDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.mapping.JdbcValue;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.RenderContextFactory;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.sql.AssignValue;
+import org.springframework.data.relational.core.sql.Assignments;
+import org.springframework.data.relational.core.sql.Condition;
+import org.springframework.data.relational.core.sql.SQL;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.core.sql.Update;
+import org.springframework.data.relational.core.sql.render.SqlRenderer;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+/**
+ * Decorates the default {@link DataAccessStrategy} to fix {@code save()} of entities with a composite/embedded
+ * {@code @Id} on YDB.
+ * <p>
+ * Spring Data JDBC's generated {@code UPDATE} statement includes the composite id's own columns in the
+ * {@code SET} clause (see {@link YdbColumns} for the root cause). YDB, unlike most relational databases, rejects
+ * any {@code UPDATE ... SET pkColumn = ...} on compilation, regardless of the value - see
+ * https://st.yandex-team.ru/YDBREQUESTS-8347 and the upstream report
+ * https://github.com/spring-projects/spring-data-relational/issues/2338.
+ * <p>
+ * For entities with a simple (non-embedded) id, this class delegates to the default strategy unchanged - only
+ * composite ids are affected by the bug.
+ */
+public class YdbDataAccessStrategy extends DelegatingDataAccessStrategy {
+
+    private static final SqlIdentifier OLD_VERSION_PARAMETER = SqlIdentifier.unquoted("___ydb_oldOptimisticLockingVersion");
+
+    private final NamedParameterJdbcOperations operations;
+    private final JdbcConverter converter;
+    private final RelationalMappingContext context;
+    private final SqlRenderer sqlRenderer;
+    private final Map<Class<?>, Optional<PreparedUpdate>> preparedUpdates = new ConcurrentHashMap<>();
+
+    public YdbDataAccessStrategy(DataAccessStrategy delegate, NamedParameterJdbcOperations operations,
+            JdbcConverter converter, Dialect dialect) {
+
+        super(delegate);
+        this.operations = operations;
+        this.converter = converter;
+        this.context = converter.getMappingContext();
+        this.sqlRenderer = SqlRenderer.create(new RenderContextFactory(dialect).createRenderContext());
+    }
+
+    @Override
+    public <S> boolean update(S instance, Class<S> domainType) {
+
+        Optional<PreparedUpdate> prepared = prepare(domainType);
+        if (prepared.isEmpty()) {
+            return super.update(instance, domainType);
+        }
+
+        PreparedUpdate update = prepared.get();
+        if (update.updateSql == null) {
+            return true;
+        }
+
+        MapSqlParameterSource params = toParameters(instance, update.entity);
+        return operations.update(update.updateSql, params) != 0;
+    }
+
+    @Override
+    public <S> boolean updateWithVersion(S instance, Class<S> domainType, Number previousVersion) {
+
+        Optional<PreparedUpdate> prepared = prepare(domainType);
+        if (prepared.isEmpty()) {
+            return super.updateWithVersion(instance, domainType, previousVersion);
+        }
+
+        PreparedUpdate update = prepared.get();
+        if (update.updateWithVersionSql == null) {
+            // no @Version property - behave like a plain update
+            return update(instance, domainType);
+        }
+
+        MapSqlParameterSource params = toParameters(instance, update.entity);
+        params.addValue(paramName(OLD_VERSION_PARAMETER), previousVersion);
+
+        int affected = operations.update(update.updateWithVersionSql, params);
+        if (affected == 0) {
+            throw new OptimisticLockingFailureException(
+                    "Optimistic lock exception on saving entity of type " + domainType.getName());
+        }
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <S> Optional<PreparedUpdate> prepare(Class<S> domainType) {
+        return preparedUpdates.computeIfAbsent(domainType, type -> {
+
+            RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(type);
+            RelationalPersistentProperty idProperty = entity.getRequiredIdProperty();
+
+            if (!idProperty.isEmbedded()) {
+                // simple id - not affected by the bug, let the default strategy handle it
+                return Optional.empty();
+            }
+
+            return Optional.of(buildPreparedUpdate(entity));
+        });
+    }
+
+    private PreparedUpdate buildPreparedUpdate(RelationalPersistentEntity<?> entity) {
+
+        Table table = Table.create(entity.getQualifiedTableName());
+        YdbColumns columns = YdbColumns.resolve(entity, context, converter);
+
+        if (columns.getUpdatableColumns().isEmpty() || columns.getIdColumns().isEmpty()) {
+            return new PreparedUpdate(entity, null, null);
+        }
+
+        List<AssignValue> assignments = columns.getUpdatableColumns().stream()
+                .map(column -> Assignments.value(table.column(column), SQL.bindMarker(":" + paramName(column))))
+                .collect(Collectors.toList());
+
+        Condition idCondition = null;
+        for (SqlIdentifier idColumn : columns.getIdColumns()) {
+
+            Condition equalsId = table.column(idColumn).isEqualTo(SQL.bindMarker(":" + paramName(idColumn)));
+            idCondition = idCondition == null ? equalsId : idCondition.and(equalsId);
+        }
+
+        String updateSql = sqlRenderer.render(Update.builder().table(table).set(assignments).where(idCondition).build());
+
+        String updateWithVersionSql = null;
+        RelationalPersistentProperty versionProperty = entity.getVersionProperty();
+        if (versionProperty != null) {
+
+            Condition withOldVersion = idCondition.and(table.column(versionProperty.getColumnName())
+                    .isEqualTo(SQL.bindMarker(":" + paramName(OLD_VERSION_PARAMETER))));
+
+            updateWithVersionSql = sqlRenderer
+                    .render(Update.builder().table(table).set(assignments).where(withOldVersion).build());
+        }
+
+        return new PreparedUpdate(entity, updateSql, updateWithVersionSql);
+    }
+
+    private MapSqlParameterSource toParameters(Object instance, RelationalPersistentEntity<?> entity) {
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        collectValues(instance, entity, "", params);
+        return params;
+    }
+
+    private void collectValues(Object instance, RelationalPersistentEntity<?> entity, String prefix,
+            MapSqlParameterSource target) {
+
+        PersistentPropertyAccessor<?> accessor = entity.getPropertyAccessor(instance);
+
+        entity.doWithAll(property -> {
+
+            if (!property.isEntity()) {
+
+                SqlIdentifier columnName = property.getColumnName().transform(prefix::concat);
+                Object value = accessor.getProperty(property);
+
+                Class<?> columnType = converter.getColumnType(property);
+                SQLType sqlType = converter.getTargetSqlType(property);
+                JdbcValue jdbcValue = converter.writeJdbcValue(value, columnType, sqlType);
+
+                target.addValue(paramName(columnName), jdbcValue.getValue(), jdbcValue.getJdbcType().getVendorTypeNumber());
+            } else if (property.isEmbedded()) {
+
+                Object embeddedValue = accessor.getProperty(property);
+                if (embeddedValue == null) {
+                    return;
+                }
+
+                RelationalPersistentEntity<?> embeddedEntity = context
+                        .getRequiredPersistentEntity(converter.getColumnType(property));
+
+                collectValues(embeddedValue, embeddedEntity, prefix + property.getEmbeddedPrefix(), target);
+            }
+        });
+    }
+
+    private static String paramName(SqlIdentifier identifier) {
+        return identifier.getReference().replaceAll("[^A-Za-z0-9_]", "_");
+    }
+
+    private static final class PreparedUpdate {
+
+        private final RelationalPersistentEntity<?> entity;
+        private final String updateSql;
+        private final String updateWithVersionSql;
+
+        private PreparedUpdate(RelationalPersistentEntity<?> entity, String updateSql, String updateWithVersionSql) {
+            this.entity = entity;
+            this.updateSql = updateSql;
+            this.updateWithVersionSql = updateWithVersionSql;
+        }
+    }
+}

--- a/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/AbstractYdbJdbcConfiguration.java
+++ b/spring-data-jdbc-ydb/src/main/java/tech/ydb/data/repository/config/AbstractYdbJdbcConfiguration.java
@@ -1,8 +1,12 @@
 package tech.ydb.data.repository.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.DefaultJdbcTypeFactory;
 import org.springframework.data.jdbc.core.convert.JdbcArrayColumns;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
@@ -14,6 +18,7 @@ import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
+import tech.ydb.data.core.convert.YdbDataAccessStrategy;
 import tech.ydb.data.core.convert.YdbMappingJdbcConverter;
 
 /**
@@ -54,5 +59,23 @@ public class AbstractYdbJdbcConfiguration extends AbstractJdbcConfiguration {
         );
 
         return new YdbMappingJdbcConverter(mappingContext, relationResolver, conversions, jdbcTypeFactory);
+    }
+
+    /**
+     * Decorates the framework-provided {@code dataAccessStrategyBean} to work around a Spring Data JDBC
+     * limitation with composite (embedded) {@code @Id} entities that makes {@code save()} of an existing entity
+     * fail on YDB with "Cannot update primary key column" - see {@link YdbDataAccessStrategy} for details.
+     * <p>
+     * This is a separate, {@link Primary @Primary} bean rather than an override of
+     * {@code dataAccessStrategyBean(...)} because that method's parameter type ({@code Dialect} vs.
+     * {@code JdbcDialect}) differs between the Spring Data JDBC versions this module supports, while
+     * {@code DataAccessStrategy} and {@code Dialect} themselves are stable across all of them.
+     */
+    @Bean
+    @Primary
+    public DataAccessStrategy ydbDataAccessStrategy(@Qualifier("dataAccessStrategyBean") DataAccessStrategy defaultStrategy,
+            NamedParameterJdbcOperations operations, JdbcConverter jdbcConverter, Dialect dialect) {
+
+        return new YdbDataAccessStrategy(defaultStrategy, operations, jdbcConverter, dialect);
     }
 }

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/CompositeKeyUpdateTest.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/CompositeKeyUpdateTest.java
@@ -1,0 +1,63 @@
+package tech.ydb.data.composite_key;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import tech.ydb.data.YdbBaseTest;
+import tech.ydb.data.composite_key.entity.CompositeKeyEntity;
+import tech.ydb.data.composite_key.entity.CompositeKeyId;
+import tech.ydb.data.composite_key.repository.CompositeKeyRepository;
+
+/**
+ * Reproduces YDBREQUESTS-8347: {@code save()} of an existing entity with a composite (embedded) {@code @Id}
+ * used to fail with "Cannot update primary key column", because Spring Data JDBC's generated {@code UPDATE}
+ * included the id's own columns in {@code SET} (see https://github.com/spring-projects/spring-data-relational/issues/2338).
+ * <p>
+ * Verification reads the persisted row directly via {@link NamedParameterJdbcTemplate} rather than
+ * {@code repository.findById(...)}, because hydrating an entity with a composite id back from a row currently
+ * fails in Spring Data JDBC 4.0.3 with an unrelated bug ("Cannot obtain ColumnInfo for embedded path", thrown
+ * from {@code DefaultAggregatePath}/{@code MappingRelationalConverter}, entirely outside of this module's
+ * {@code DataAccessStrategy}) - out of scope for this fix, which is only about the {@code UPDATE} statement.
+ */
+public class CompositeKeyUpdateTest extends YdbBaseTest {
+
+    @Autowired
+    private CompositeKeyRepository repository;
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Test
+    public void updateExistingEntityWithCompositeId() {
+
+        CompositeKeyId id = new CompositeKeyId("workspace-1", "scope-1");
+
+        CompositeKeyEntity inserted = repository.save(new CompositeKeyEntity(id, "ACTIVE"));
+        Assertions.assertNotNull(inserted.getVersion(), "expected @Version to be populated after insert");
+        Assertions.assertEquals("ACTIVE", currentStatus(id));
+
+        // reuses the instance returned by the insert (with its @Version populated), so save() below
+        // takes the "update an existing aggregate" path instead of inserting a new row
+        inserted.setStatus("ARCHIVED");
+        repository.save(inserted);
+
+        Assertions.assertEquals("ARCHIVED", currentStatus(id));
+    }
+
+    private String currentStatus(CompositeKeyId id) {
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("workspaceId", id.getWorkspaceId())
+                .addValue("scopeId", id.getScopeId());
+
+        Map<String, Object> row = jdbcTemplate.queryForMap(
+                "select status from composite_key_entity where workspace_id = :workspaceId and scope_id = :scopeId",
+                params);
+
+        return (String) row.get("status");
+    }
+}

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/entity/CompositeKeyEntity.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/entity/CompositeKeyEntity.java
@@ -1,0 +1,46 @@
+package tech.ydb.data.composite_key.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ * Reproduces the entity shape from YDBREQUESTS-8347: a composite {@code @Id} together with a {@code @Version}
+ * property, whose {@code save()} of an already-persisted instance used to fail on YDB with
+ * "Cannot update primary key column".
+ */
+@Table("composite_key_entity")
+public class CompositeKeyEntity {
+
+    @Id
+    private CompositeKeyId id;
+
+    private String status;
+
+    @Version
+    private Long version;
+
+    public CompositeKeyEntity() {
+    }
+
+    public CompositeKeyEntity(CompositeKeyId id, String status) {
+        this.id = id;
+        this.status = status;
+    }
+
+    public CompositeKeyId getId() {
+        return id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+}

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/entity/CompositeKeyId.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/entity/CompositeKeyId.java
@@ -1,0 +1,47 @@
+package tech.ydb.data.composite_key.entity;
+
+import java.util.Objects;
+
+/**
+ * Composite id reproducing YDBREQUESTS-8347: an {@code @Id} property backed by a value object with several
+ * fields instead of a single scalar column.
+ */
+public class CompositeKeyId {
+    private final String workspaceId;
+    private final String scopeId;
+
+    public CompositeKeyId(String workspaceId, String scopeId) {
+        this.workspaceId = workspaceId;
+        this.scopeId = scopeId;
+    }
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public String getScopeId() {
+        return scopeId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CompositeKeyId)) {
+            return false;
+        }
+        CompositeKeyId other = (CompositeKeyId) o;
+        return Objects.equals(workspaceId, other.workspaceId) && Objects.equals(scopeId, other.scopeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workspaceId, scopeId);
+    }
+
+    @Override
+    public String toString() {
+        return "CompositeKeyId{workspaceId='" + workspaceId + "', scopeId='" + scopeId + "'}";
+    }
+}

--- a/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/repository/CompositeKeyRepository.java
+++ b/spring-data-jdbc-ydb/src/test/java/tech/ydb/data/composite_key/repository/CompositeKeyRepository.java
@@ -1,0 +1,9 @@
+package tech.ydb.data.composite_key.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import tech.ydb.data.composite_key.entity.CompositeKeyEntity;
+import tech.ydb.data.composite_key.entity.CompositeKeyId;
+
+public interface CompositeKeyRepository extends CrudRepository<CompositeKeyEntity, CompositeKeyId> {
+}

--- a/spring-data-jdbc-ydb/src/test/resources/changelogs/changelog.yaml
+++ b/spring-data-jdbc-ydb/src/test/resources/changelogs/changelog.yaml
@@ -5,6 +5,9 @@ databaseChangeLog:
   - include:
       file: "books.yaml"
       relativeToChangelogFile: true
+  - include:
+      file: "composite_key_entity.yaml"
+      relativeToChangelogFile: true
   - changeSet:
       id: "insert-all-types-table"
       author: "Madiyar Nurgazin"

--- a/spring-data-jdbc-ydb/src/test/resources/changelogs/composite_key_entity.yaml
+++ b/spring-data-jdbc-ydb/src/test/resources/changelogs/composite_key_entity.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: "composite_key_entity"
+      author: "YDBREQUESTS-8347"
+      changes:
+        - createTable:
+            tableName: composite_key_entity
+            columns:
+              - column:
+                  name: workspace_id
+                  type: varchar
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: scope_id
+                  type: varchar
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: status
+                  type: varchar
+              - column:
+                  name: version
+                  type: bigint
+      rollback:
+        - dropTable:
+            tableName: composite_key_entity


### PR DESCRIPTION
## Summary

`save()` of an already-persisted entity with a composite (embedded) `@Id` fails on YDB with `Cannot update primary key column` (YDB error 400080). Reported in [YDBREQUESTS-8347](https://st.yandex-team.ru/YDBREQUESTS-8347).

**Root cause:** Spring Data JDBC's `SqlGenerator.Columns` decides whether a column belongs to the id by checking `property.getOwner().isIdProperty(property)`. For a property reached by recursing into an embedded/composite id, the "owner" passed to that check is the id wrapper type itself (e.g. a `ScopeInventoryId` record), which has no `@Id`-annotated field of its own - so none of the composite id's own columns are recognized as id columns, and all of them end up in the generated `UPDATE ... SET ...` clause. Most relational databases tolerate `SET pk = pk` as a no-op; YDB rejects it at compile time regardless of the value.

This is confirmed upstream at [spring-projects/spring-data-relational#2338](https://github.com/spring-projects/spring-data-relational/issues/2338) (exact same root cause, same `SqlGenerator` lines), but no fix has landed there yet.

## Fix

`YdbDataAccessStrategy` decorates the framework-provided `DataAccessStrategy`:
- entities with a simple id are delegated to the default strategy unchanged;
- entities with a composite/embedded id get a regenerated `UPDATE`/"update with version" statement, built from the entity's mapping metadata (`YdbColumns`), that correctly excludes *all* of the id's own columns (including nested ones) from `SET`, while still using them - and the `@Version` column - in `WHERE`.

It's wired in as a separate `@Primary` bean (`AbstractYdbJdbcConfiguration#ydbDataAccessStrategy`) rather than an override of `dataAccessStrategyBean(...)`, because that method's dialect parameter type (`Dialect` vs `JdbcDialect`) differs between the Spring Data JDBC versions this module supports (3.4 / 3.5 / 4.0), while `DataAccessStrategy` and `Dialect` themselves are stable across all of them.

## Test plan

- [x] `mvn clean package` / `clean test` green under all three profiles (`spring-boot-minimal` 3.4.0, `spring-boot3` 3.5.11, `spring-boot4` 4.0.3), including the existing `books`/`all_types_table` suites (regression check for simple-id entities).
- [x] New `CompositeKeyUpdateTest`, gated to the `spring-boot4` profile (composite `@Id` support itself requires Spring Data JDBC 4.0), run against a real YDB container: inserts an entity with a composite `@Id` + `@Version`, then updates it via `repository.save()` on the already-persisted instance. Before this change that `save()` throws `Cannot update primary key column`; after, the generated SQL is `UPDATE composite_key_entity SET status = ?, version = ? WHERE ... workspace_id = ? AND scope_id = ? AND version = ?`.
- Note: verification reads the row back via `NamedParameterJdbcTemplate` rather than `repository.findById(...)`, because hydrating an entity with a composite id back from a row currently fails in Spring Data JDBC 4.0.3 with an unrelated bug (`Cannot obtain ColumnInfo for embedded path`, thrown from `DefaultAggregatePath`/`MappingRelationalConverter`, entirely outside this module's `DataAccessStrategy`) - out of scope here, since this PR is only about the `UPDATE` statement.

/cc @alex268 as the module's active maintainer - would appreciate a look, especially at how `ydbDataAccessStrategy` is wired into `AbstractYdbJdbcConfiguration`.