### PR TITLE
Expose YDB paths through the default Trino schema

### DIFF
--- a/ydb-trino-adapter/README.md
+++ b/ydb-trino-adapter/README.md
@@ -68,6 +68,10 @@ USE ydb_prod.default;
 SELECT * FROM "sales/eu/orders";
 ```
 
+Each YDB path component is limited to 255 characters. The connector does not
+apply that limit to the complete relative path, so a deeper path remains valid
+when every component is valid.
+
 Catalogs may be joined, but the join is executed by Trino rather than pushed
 down to YDB:
 
@@ -77,11 +81,17 @@ FROM ydb_prod.default."sales/eu/orders" p
 JOIN ydb_analytics.default.customer_segment a ON p.customer_id = a.customer_id;
 ```
 
-The intended future federation form is a single statement that reads from
-several catalogs and writes to one; it would have no distributed snapshot or
-distributed commit. Explicit transactions containing a YDB write are currently
-rejected because this connector supports autocommit-only writes. This connector
-slice has not integration-tested two-catalog federation.
+Trino 479 permits one autocommit statement to read from several catalogs and
+write to one target catalog. This YDB federation topology has not yet been
+integration-tested and does not provide a cross-catalog snapshot or distributed
+commit.
+
+Cross-catalog reads may also run in an explicit transaction. YDB is a
+single-statement-write connector: when YDB is the first or only write target,
+Trino rejects the write before connector mutation with `Catalog only supports
+writes using autocommit: <catalog>`. A read-only transaction or an earlier write
+to another catalog can instead produce the corresponding read-only or
+multi-catalog-write error.
 
 Trino 479 can alternatively enable the experimental deployment feature
 `catalog.management=dynamic` and create the same catalog instances with

--- a/ydb-trino-adapter/README.md
+++ b/ydb-trino-adapter/README.md
@@ -25,3 +25,73 @@ docker-compose up -d
 
 docker exec -it ydb-trino trino
 ```
+
+## YDB catalogs and table paths
+
+Configure one static Trino catalog for each YDB database. A catalog is a
+connection and security boundary; the connector exposes only the virtual
+`default` schema and does not discover YDB databases.
+
+For example, deploy these two files under Trino's `etc/catalog/` directory.
+The environment values must be injected from the deployment secret manager;
+they are placeholders, not credentials to copy into source control.
+
+`ydb_prod.properties`:
+
+```properties
+connector.name=ydb
+connection-url=${ENV:YDB_PROD_JDBC_URL}
+```
+
+`ydb_analytics.properties`:
+
+```properties
+connector.name=ydb
+connection-url=${ENV:YDB_ANALYTICS_JDBC_URL}
+```
+
+For example, `YDB_PROD_JDBC_URL` is a secret reference resolving to a complete
+JDBC URL for the production database, including any authentication material.
+Never store a real token or credential in a catalog file. The bundled
+[`examples/trino/etc/catalog/ydb.properties`](examples/trino/etc/catalog/ydb.properties)
+is the working local single-database example mounted by
+`examples/docker-compose.yml`; it intentionally points at `ydb-local`. For
+production, create `ydb_prod.properties` and a separate analytics catalog file
+using the secret references above.
+
+A table name is the complete YDB path relative to that catalog's configured
+database root. Select the only schema, then quote a nested path as one Trino
+identifier:
+
+```sql
+USE ydb_prod.default;
+SELECT * FROM "sales/eu/orders";
+```
+
+Catalogs may be joined, but the join is executed by Trino rather than pushed
+down to YDB:
+
+```sql
+SELECT p.order_id, a.segment
+FROM ydb_prod.default."sales/eu/orders" p
+JOIN ydb_analytics.default.customer_segment a ON p.customer_id = a.customer_id;
+```
+
+The intended future federation form is a single statement that reads from
+several catalogs and writes to one; it would have no distributed snapshot or
+distributed commit. Explicit transactions containing a YDB write are currently
+rejected because this connector supports autocommit-only writes. This connector
+slice has not integration-tested two-catalog federation.
+
+Trino 479 can alternatively enable the experimental deployment feature
+`catalog.management=dynamic` and create the same catalog instances with
+`CREATE CATALOG`. This is not YDB database discovery. Do not place secrets in a
+`CREATE CATALOG` statement: Trino logs the complete statement and displays it
+in the Web UI. Use static catalog files and secret references for production
+credentials.
+
+```sql
+CREATE CATALOG ydb_analytics
+USING ydb
+WITH ("connection-url" = 'jdbc:ydb:grpcs://<endpoint>/<database>?token=<secret>');
+```

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -26,6 +26,86 @@ within the CI budget. An isolated local Colima run previously exceeded 11
 minutes, so MERGE scalability remains a production concern rather than a CI
 failure.
 
+## Approved namespace and catalog contract
+
+The public namespace model was agreed on 2026-08-19:
+
+- one Trino catalog is one configured YDB connector instance bound
+  to exactly one YDB database through its JDBC `connection-url` and credentials;
+- multiple YDB databases use multiple Trino catalog configurations; the
+  connector does not discover databases or publish catalogs dynamically;
+- the connector exposes exactly one virtual, non-droppable Trino schema named
+  `default`;
+- a Trino table name is the complete YDB object path relative to the configured
+  database root. Root table `orders` is `catalog.default.orders`; nested table
+  `sales/eu/orders` is `catalog.default."sales/eu/orders"`;
+- the configured database path is a connection and security boundary and never
+  becomes part of the Trino schema or table name.
+
+This keeps the native YDB path visible in SQL and avoids flattening directories
+into a list of artificial Trino schemas. Trino schemas are not hierarchical, so
+mapping `sales/eu` to a schema would still appear as one flat, quoted schema in
+SQL clients rather than as a directory tree.
+
+### Metadata and DDL behavior
+
+| Trino operation | Contract |
+| --- | --- |
+| `listSchemaNames()` | Return only `default` |
+| `listTables(Optional.empty())` | Return every accessible YDB table recursively, all in `default` |
+| `listTables(Optional.of("default"))` | Same table set as the unfiltered call |
+| `listTables()` for another schema | Return an empty list |
+| `getTableHandle(default, name)` | Resolve the validated full relative YDB path |
+| `getTableHandle()` for another schema | Return empty without querying an unrelated path |
+| `CREATE`, `DROP`, `RENAME SCHEMA` | `NOT_SUPPORTED`; `default` is virtual and cannot be changed |
+| `CREATE TABLE default."dir/table"` | Require the parent YDB directory to exist |
+| table rename | May move a table by changing its full relative path; target parent must exist |
+
+The connector must parse paths into components before producing YQL. It rejects
+absolute paths, empty components, leading/trailing or repeated `/`, `.` and
+`..`, dot-prefixed/system components, invalid YDB component names, and
+components longer than the YDB limit. The validated full path is quoted as one
+YQL identifier through the connector quoting helper. It is not assembled by
+call-site string concatenation.
+
+Trino 479 normalizes SQL identifiers to lowercase, including delimited
+identifiers. YDB paths are case-sensitive. A lowercase Trino name may resolve to
+one unique case-insensitive remote path; case-only collisions must fail with an
+explicit ambiguous-name error rather than selecting an arbitrary object.
+
+### Catalog provisioning and federation
+
+Static catalog property files are the production default. For example,
+`ydb_prod.properties` and `ydb_analytics.properties` contain separate YDB JDBC
+URLs and expose `ydb_prod.default` and `ydb_analytics.default`. Trino 479 dynamic
+catalog management can optionally create the same connector instances with
+`CREATE CATALOG`, but it is an experimental Trino deployment feature and not
+YDB database discovery by the connector. Sensitive catalog properties must not
+be placed directly in SQL because the complete statement is logged and visible
+in the Trino Web UI.
+
+Federated reads qualify each source by catalog. Cross-catalog joins run in
+Trino; join pushdown requires both tables to belong to the same catalog.
+Reading from multiple catalogs and writing to one is allowed when the target
+operation is supported, but there is no global snapshot or distributed commit
+across sources. Trino 479 rejects writes to more than one catalog in one
+transaction with `MULTI_CATALOG_WRITE_CONFLICT`.
+
+### First implementation slice
+
+1. Introduce one path parser/validator used by metadata and table operations.
+2. Change the synthetic schema from `ydb` to `default`.
+3. Make `listTables` and `getTableHandle` honor the schema filter and preserve
+   the complete relative YDB table path.
+4. Map only genuine remote not-found results to an absent table handle; preserve
+   other JDBC/YDB failures.
+5. Add focused tests for root and nested tables, an unknown schema, path
+   traversal, dot-prefixed paths, case-only ambiguity, and full-path quoting.
+
+This slice does not enable schema DDL capabilities or change capability flags.
+Catalog provisioning and cross-catalog federation tests follow as a separate
+integration slice.
+
 ## P0 — harden MERGE scalability and atomicity
 
 1. Replace row-by-row prepared-statement execution in `YdbMergeSink` with a
@@ -85,7 +165,8 @@ need this treatment. YDB `Date` starts at the Unix epoch; see
 
 ## Later capability work
 
-- schema-as-YDB-path design for CREATE/DROP/RENAME SCHEMA;
+- catalog provisioning and YDB-to-YDB federation coverage for the approved
+  single-`default`-schema namespace model;
 - List/Dict/Struct mappings for Trino ARRAY/MAP/ROW;
 - views, comments, rename column, and type changes after checking current YQL
   semantics;

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -19,12 +19,17 @@ have been verified locally against a real YDB test container:
 - retry classification through the YDB SDK status model, with fresh merge
   connections and rollback-before-close.
 
-GitHub Actions is green on PR #240: 314 tests run, 0 failed, 0 errors, 84
-skipped. This includes 36 smoke tests (4 skipped) and 278 connector tests (80
-skipped). The inherited `testMergeLarge` runs without an override and completes
-within the CI budget. An isolated local Colima run previously exceeded 11
-minutes, so MERGE scalability remains a production concern rather than a CI
-failure.
+GitHub Actions on PR #240 verified the DML baseline: 314 tests run, 0 failures,
+0 errors, and 84 skipped. This included 36 smoke tests (4 skipped) and 278
+connector tests (80 skipped). The inherited `testMergeLarge` runs without an
+override and completes within the CI budget. An isolated local Colima run
+previously exceeded 11 minutes, so MERGE scalability remains a production
+concern rather than a CI failure.
+
+Fresh local JDK 25 namespace validation (2026-08-20) reported 324 discovered
+tests: 0 failures, 0 errors, and 84 skipped, leaving 240 executed tests passed.
+It included 5 `TestYdbTablePath` tests, 283 connector tests (80 skipped), and
+36 smoke tests (4 skipped); no other test classes ran.
 
 ## Approved namespace and catalog contract
 
@@ -86,24 +91,28 @@ in the Trino Web UI.
 
 Federated reads qualify each source by catalog. Cross-catalog joins run in
 Trino; join pushdown requires both tables to belong to the same catalog.
-Reading from multiple catalogs and writing to one is allowed when the target
+Single-statement read-many/write-one is the intended form when the target
 operation is supported, but there is no global snapshot or distributed commit
-across sources. Trino 479 rejects writes to more than one catalog in one
-transaction with `MULTI_CATALOG_WRITE_CONFLICT`.
+across sources. Explicit transactions containing a YDB write are currently
+rejected because the connector supports autocommit-only writes; this happens
+before a multi-catalog write conflict could be reached. Federation remains an
+unverified future integration slice.
 
-### First implementation slice
+### Implemented namespace slice (verified 2026-08-20)
 
-1. Introduce one path parser/validator used by metadata and table operations.
-2. Change the synthetic schema from `ydb` to `default`.
-3. Make `listTables` and `getTableHandle` honor the schema filter and preserve
+This slice implements the following items:
+
+1. Introduced one path parser/validator used by metadata and table operations.
+2. Changed the synthetic schema from `ydb` to `default`.
+3. Made `listTables` and `getTableHandle` honor the schema filter and preserve
    the complete relative YDB table path.
-4. Map only genuine remote not-found results to an absent table handle; preserve
+4. Mapped only genuine remote not-found results to an absent table handle and preserved
    other JDBC/YDB failures.
-5. Add focused tests for root and nested tables, an unknown schema, path
+5. Added focused tests for root and nested tables, an unknown schema, path
    traversal, dot-prefixed paths, case-only ambiguity, and full-path quoting.
 
 This slice does not enable schema DDL capabilities or change capability flags.
-Catalog provisioning and cross-catalog federation tests follow as a separate
+Catalog provisioning and cross-catalog federation remain a separate, unverified
 integration slice.
 
 ## P0 — harden MERGE scalability and atomicity

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -26,9 +26,9 @@ override and completes within the CI budget. An isolated local Colima run
 previously exceeded 11 minutes, so MERGE scalability remains a production
 concern rather than a CI failure.
 
-Fresh local JDK 25 namespace validation (2026-08-20) reported 324 discovered
-tests: 0 failures, 0 errors, and 84 skipped, leaving 240 executed tests passed.
-It included 5 `TestYdbTablePath` tests, 283 connector tests (80 skipped), and
+Fresh local JDK 25 namespace validation (2026-08-20) reported 327 discovered
+tests: 0 failures, 0 errors, and 84 skipped, leaving 243 executed tests passed.
+It included 5 `TestYdbTablePath` tests, 286 connector tests (80 skipped), and
 36 smoke tests (4 skipped); no other test classes ran.
 
 ## Approved namespace and catalog contract
@@ -69,9 +69,10 @@ SQL clients rather than as a directory tree.
 The connector must parse paths into components before producing YQL. It rejects
 absolute paths, empty components, leading/trailing or repeated `/`, `.` and
 `..`, dot-prefixed/system components, invalid YDB component names, and
-components longer than the YDB limit. The validated full path is quoted as one
-YQL identifier through the connector quoting helper. It is not assembled by
-call-site string concatenation.
+components longer than the 255-character YDB component limit. It does not impose
+an artificial 255-character limit on the complete relative path. The validated
+full path is quoted as one YQL identifier through the connector quoting helper.
+It is not assembled by call-site string concatenation.
 
 Trino 479 normalizes SQL identifiers to lowercase, including delimited
 identifiers. YDB paths are case-sensitive. A lowercase Trino name may resolve to
@@ -91,12 +92,17 @@ in the Trino Web UI.
 
 Federated reads qualify each source by catalog. Cross-catalog joins run in
 Trino; join pushdown requires both tables to belong to the same catalog.
-Single-statement read-many/write-one is the intended form when the target
-operation is supported, but there is no global snapshot or distributed commit
-across sources. Explicit transactions containing a YDB write are currently
-rejected because the connector supports autocommit-only writes; this happens
-before a multi-catalog write conflict could be reached. Federation remains an
-unverified future integration slice.
+Trino 479 permits one autocommit statement to read from several catalogs and
+write to one target catalog when the target operation is supported. This
+read-many/write-one YDB topology remains unverified and provides neither a
+cross-catalog snapshot nor a distributed commit.
+
+Cross-catalog reads may run in an explicit transaction. YDB is a
+single-statement-write connector: when YDB is the first or only write target,
+Trino rejects the write before connector mutation with `Catalog only supports
+writes using autocommit: <catalog>`. A read-only transaction or an earlier write
+to another catalog can instead surface the corresponding read-only or
+multi-catalog-write error.
 
 ### Implemented namespace slice (verified 2026-08-20)
 
@@ -110,10 +116,18 @@ This slice implements the following items:
    other JDBC/YDB failures.
 5. Added focused tests for root and nested tables, an unknown schema, path
    traversal, dot-prefixed paths, case-only ambiguity, and full-path quoting.
+6. Made relation-comment metadata and opt-in bulk column metadata honor the
+   virtual `default` schema, recursive paths, and case-only collision checks.
+   Comment writes remain unsupported, and bulk column metadata remains opt-in.
 
 This slice does not enable schema DDL capabilities or change capability flags.
 Catalog provisioning and cross-catalog federation remain a separate, unverified
 integration slice.
+
+The real-YDB `testNestedTablePathLongerThanSingleComponentLimit` passed in the
+final full suite. It covers a complete relative path longer than 255 characters
+whose components are each at most 255 characters, including listing, selection,
+rename, and cleanup.
 
 ## P0 — harden MERGE scalability and atomicity
 

--- a/ydb-trino-adapter/docs/plans/2026-08-19-default-namespace-metadata.md
+++ b/ydb-trino-adapter/docs/plans/2026-08-19-default-namespace-metadata.md
@@ -1,0 +1,321 @@
+# Default Namespace Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose one virtual Trino schema named `default` and address every YDB table by its validated full path relative to the configured database root.
+
+**Architecture:** Keep catalog/database selection in Trino catalog configuration. Add one small immutable path type that validates user table names and provides case-insensitive comparison keys. `YdbClient` remains responsible for JDBC metadata: it lists visible remote paths recursively, rejects ambiguous case-only matches, returns absent only for genuine missing tables, and stores the resolved remote path in the table handle.
+
+**Tech Stack:** Java 25, Trino 479 JDBC SPI, YDB JDBC 2.3.18, YDB SDK/test helper 2.3.13, JUnit 5, AssertJ, Maven, Testcontainers.
+
+**Spec:** `ydb-trino-adapter/ROADMAP.md`, section “Approved namespace and catalog contract”.
+
+## Global Constraints
+
+- Work only in `ydb-trino-adapter/`; do not change unrelated modules.
+- One Trino catalog is bound to one YDB database by `connection-url` and credentials.
+- Expose exactly one virtual schema named `default`; schema DDL stays unsupported.
+- The table name is the complete YDB path relative to the configured database root.
+- Never concatenate a user path directly into YQL outside the existing identifier quoting helpers.
+- Reject absolute, empty, repeated-separator, trailing-separator, `.`, `..`, dot-prefixed/system, invalid-character, and over-255-character path components.
+- Preserve remote case only after a unique case-insensitive metadata match; reject case-only collisions explicitly.
+- Do not change connector capability flags in this slice.
+- Tests may be added before or after implementation according to risk; this plan does not require TDD.
+- Use JDK 25 and the Docker/Testcontainers settings from the root `AGENTS.md`.
+
+---
+
+### Task 1: Add the validated YDB table-path value type
+
+**Files:**
+- Create: `ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java`
+- Create: `ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java`
+
+**Interfaces:**
+- Produces: `YdbTablePath.fromUserInput(String)` for strict user validation.
+- Produces: `YdbTablePath.fromRemoteMetadata(String)` returning an empty optional for hidden/system paths that must not be published.
+- Produces: `value()` for the validated relative path and `comparisonKey()` for `Locale.ROOT` case-insensitive matching.
+
+- [ ] **Step 1: Implement the immutable path type**
+
+Create a package-private record with this interface and validation structure:
+
+```java
+record YdbTablePath(String value)
+{
+    private static final int MAX_COMPONENT_LENGTH = 255;
+    private static final Pattern COMPONENT = Pattern.compile("[A-Za-z0-9._-]+");
+
+    static YdbTablePath fromUserInput(String value)
+    {
+        return parseUserInput(value);
+    }
+
+    static Optional<YdbTablePath> fromRemoteMetadata(String value)
+    {
+        return parse(value, false);
+    }
+
+    String comparisonKey()
+    {
+        return value.toLowerCase(Locale.ROOT);
+    }
+}
+```
+
+Implement both parsing paths through one private component validator using `split("/", -1)`. `parseUserInput` must throw `TrinoException(INVALID_ARGUMENTS, ...)` with the rejected path and a non-sensitive reason. `fromRemoteMetadata` must return `Optional.empty()` for a dot-prefixed component so connector/system paths are hidden, but must throw `JDBC_ERROR` if JDBC reports another structurally invalid table path.
+
+- [ ] **Step 2: Add focused unit coverage**
+
+Test these exact categories in `TestYdbTablePath`:
+
+```java
+assertThat(YdbTablePath.fromUserInput("orders").value()).isEqualTo("orders");
+assertThat(YdbTablePath.fromUserInput("sales/eu/orders").value()).isEqualTo("sales/eu/orders");
+assertThat(YdbTablePath.fromUserInput("sales.eu/orders-v2").comparisonKey())
+        .isEqualTo("sales.eu/orders-v2");
+```
+
+Iterate over `""`, `"/orders"`, `"orders/"`, `"a//b"`, `"."`, `".."`, `"a/../b"`, `".sys/table"`, and `"a/$/b"` in one test; each must fail with `INVALID_ARGUMENTS`. Add a 255-character passing component and a 256-character failing component. Verify `fromRemoteMetadata(".sys/table")` is empty and malformed non-system metadata raises `JDBC_ERROR`.
+
+- [ ] **Step 3: Run the path unit test**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+  mvn -f ydb-trino-adapter/pom.xml -Dtest=TestYdbTablePath test
+```
+
+Expected: `TestYdbTablePath` passes with zero skipped tests.
+
+- [ ] **Step 4: Commit the value type**
+
+```bash
+git add ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java \
+        ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+git commit -m "Validate YDB table paths"
+```
+
+---
+
+### Task 2: Make JDBC metadata schema-aware and path-aware
+
+**Files:**
+- Modify: `ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java:127`
+- Test: `ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java`
+
+**Interfaces:**
+- Consumes: `YdbTablePath.fromUserInput`, `fromRemoteMetadata`, `value`, and `comparisonKey` from Task 1.
+- Produces: package-visible `YdbClient.DEFAULT_SCHEMA` with value `default` for runner/tests.
+- Produces: `listRemoteTablePaths(Connection)` and `resolveRemoteTablePath(Connection, YdbTablePath)` as private JDBC metadata helpers.
+
+- [ ] **Step 1: Replace the synthetic schema constant**
+
+Replace `private static final String YDB_SCHEMA = "ydb"` with:
+
+```java
+static final String DEFAULT_SCHEMA = "default";
+```
+
+Use `DEFAULT_SCHEMA` for schema listing, logical table handles, and primary-key lookup fallbacks.
+
+- [ ] **Step 2: Centralize recursive table discovery**
+
+Add a helper that owns the metadata result lifecycle:
+
+```java
+private List<YdbTablePath> listRemoteTablePaths(Connection connection)
+        throws SQLException
+{
+    ImmutableList.Builder<YdbTablePath> paths = ImmutableList.builder();
+    try (ResultSet resultSet = getTables(connection, Optional.empty(), Optional.empty())) {
+        while (resultSet.next()) {
+            YdbTablePath.fromRemoteMetadata(resultSet.getString("TABLE_NAME"))
+                    .ifPresent(paths::add);
+        }
+    }
+    return paths.build();
+}
+```
+
+Before returning public table names, group paths by `comparisonKey()`. Throw `TrinoException(AMBIGUOUS_NAME, ...)` when a group has more than one distinct remote value. Do not publish an arbitrary winner.
+
+- [ ] **Step 3: Honor the schema filter in table listing**
+
+Change `getTableNames` so a non-`default` schema returns `ImmutableList.of()` before opening a connection. For `Optional.empty()` and `Optional.of("default")`, list all visible paths and return `new SchemaTableName(DEFAULT_SCHEMA, path.value())`.
+
+- [ ] **Step 4: Resolve table handles against actual remote metadata**
+
+Change `getTableHandle` to return empty immediately for another schema, parse the requested path, match recursively listed remote paths by `comparisonKey()`, and use the actual remote spelling for one match. Return empty for zero matches and `AMBIGUOUS_NAME` for multiple matches. Store the requested logical name in schema `default` and the resolved path in a schema-less `RemoteTableName`.
+
+Remove the `getColumns(...).next()` existence probe and the blanket `catch (SQLException) { return Optional.empty(); }`. Wrap metadata failures as `new TrinoException(JDBC_ERROR, "Failed to resolve YDB table " + schemaTableName, e)` and retain the cause.
+
+- [ ] **Step 5: Validate names before producing YQL or remote names**
+
+Change `toRemoteTableName` to call `YdbTablePath.fromUserInput(schemaTableName.getTableName())` and use its `value()`. Make `quoted(catalog, schema, table)` validate `table` the same way before quoting the complete path as one identifier; this covers base-JDBC CREATE operations. Validate `newTableName.getTableName()` in the public `renameTable` override before delegating to the base client. Existing handle-based DML continues to quote the already resolved remote path.
+
+- [ ] **Step 6: Add connector-level schema assertions**
+
+Add `testDefaultSchemaContract` to `TestYdbConnectorTest`. Assert `SHOW SCHEMAS FROM ydb` contains `default` and not `ydb`, `SHOW TABLES FROM ydb.default` contains `orders`, and `SELECT * FROM ydb.missing.orders` fails because the schema does not exist.
+
+- [ ] **Step 7: Run metadata-focused tests**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn -f ydb-trino-adapter/pom.xml \
+  -Dtest='TestYdbConnectorTest#testShowCreateSchema+testCreateTableSchemaNotFound+testDefaultSchemaContract' test
+```
+
+Expected: all selected methods pass; schema creation remains unsupported.
+
+- [ ] **Step 8: Commit metadata behavior**
+
+```bash
+git add ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java \
+        ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+git commit -m "Expose YDB tables through default schema"
+```
+
+---
+
+### Task 3: Exercise nested paths and path safety against real YDB
+
+**Files:**
+- Modify: `ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java:18`
+- Modify: `ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java`
+
+**Interfaces:**
+- Consumes: `YdbClient.DEFAULT_SCHEMA` and metadata behavior from Task 2.
+- Produces: package-visible `YdbQueryRunner.buildJdbcUrl(YdbHelperExtension)` for raw YDB setup where Trino cannot create a directory.
+
+- [ ] **Step 1: Use `default` in the test session**
+
+Replace `TPCH_SCHEMA = "ydb"` with `public static final String DEFAULT_SCHEMA = YdbClient.DEFAULT_SCHEMA`, build the `DistributedQueryRunner` session with it, and make `buildJdbcUrl` package-visible.
+
+- [ ] **Step 2: Add directory lifecycle helpers**
+
+Use `SchemeClient.newClient(ydb.createTransport()).build()` and absolute paths under `ydb.database()`:
+
+```java
+private static void createDirectory(String relativePath)
+{
+    try (SchemeClient client = SchemeClient.newClient(ydb.createTransport()).build()) {
+        client.makeDirectories(ydb.database() + "/" + relativePath).join().expectSuccess();
+    }
+}
+```
+
+Add cleanup that removes leaf directories after their tables are dropped. Use a random suffix for every test path.
+
+- [ ] **Step 3: Add nested-table round-trip coverage**
+
+Create a two-level directory and then `CREATE TABLE "namespace_<suffix>/eu/orders" (id bigint NOT NULL)` through Trino. Verify `SHOW TABLES`, `SELECT`, and `SHOW CREATE TABLE` use the complete relative path. Drop the table and directories in `finally`.
+
+- [ ] **Step 4: Add traversal and hidden-path negative coverage**
+
+For each of `"/orders"`, `"a//orders"`, `"a/../orders"`, and `".sys/orders"`, execute a fully qualified `SELECT` and assert an actionable `Invalid YDB table path` failure. The test must prove that `a/../orders` is rejected even though YDB normalizes it inside a database.
+
+- [ ] **Step 5: Add case-only ambiguity coverage**
+
+Create `Case_<suffix>/Orders` and `case_<suffix>/orders` directly through YDB JDBC using `YdbQueryRunner.buildJdbcUrl(ydb)` and try-with-resources:
+
+```java
+try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+        Statement statement = connection.createStatement()) {
+    statement.execute("CREATE TABLE `" + remotePath + "` (id Int64 NOT NULL, PRIMARY KEY (id))");
+}
+```
+
+The suffix is generated by the test and contains only safe identifier characters. Query the lowercase Trino path and assert an ambiguity failure naming both remote paths. Drop both tables through raw JDBC and both directories through `SchemeClient` in `finally`.
+
+- [ ] **Step 6: Run focused path tests**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn -f ydb-trino-adapter/pom.xml \
+  -Dtest='TestYdbConnectorTest#testNestedTablePath+testInvalidTablePaths+testCaseOnlyTablePathAmbiguity' test
+```
+
+Expected: all three methods pass with zero skips.
+
+- [ ] **Step 7: Commit real-YDB coverage**
+
+```bash
+git add ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java \
+        ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+git commit -m "Test nested YDB table paths"
+```
+
+---
+
+### Task 4: Update operator examples and verify the slice
+
+**Files:**
+- Modify: `ydb-trino-adapter/README.md`
+- Modify: `ydb-trino-adapter/examples/trino/etc/catalog/ydb.properties`
+- Modify only with verified counts: `ydb-trino-adapter/ROADMAP.md`
+
+**Interfaces:**
+- Consumes: the completed single-`default`-schema behavior from Tasks 1–3.
+- Produces: operator examples for one catalog per database and full-path table names.
+
+- [ ] **Step 1: Document provisioning and query UX**
+
+Add concise static catalog examples for two databases with placeholder URLs and secret references. Document `USE ydb_prod.default`, a nested table query, and a cross-catalog join. Describe `catalog.management=dynamic` plus `CREATE CATALOG` as an optional experimental Trino deployment mechanism and warn that complete statements are logged. State that cross-catalog joins execute in Trino, read-many/write-one has no distributed snapshot/commit, and Trino 479 rejects multi-catalog writes.
+
+- [ ] **Step 2: Compile with the CI JDK**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn -f ydb-trino-adapter/pom.xml -DskipTests compile
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 3: Run connector and smoke classes**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn -f ydb-trino-adapter/pom.xml \
+  -Dtest='TestYdbConnectorTest,TestYdbConnectorSmokeTest,TestYdbTablePath' test
+```
+
+Expected: no failures or errors. Record exact run/skipped counts from Surefire.
+
+- [ ] **Step 4: Run the CI-equivalent full suite**
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn --batch-mode --update-snapshots -f ydb-trino-adapter/pom.xml clean test
+```
+
+Expected: no failures or errors. Compare with `.github/workflows/ci-trino-adapter.yaml` and report passed, failed, and skipped counts.
+
+- [ ] **Step 5: Update only verified roadmap facts and commit**
+
+Append exact local counts and observed limitations to `ROADMAP.md`; do not claim federation coverage until a second catalog is exercised. Commit README, example config, and verified roadmap results as `Document YDB catalog namespace usage`.
+
+---
+
+## Small-PR sequence after this slice
+
+Each later subsystem gets its own reviewed implementation plan and branch from the then-current `main`:
+
+1. Two-catalog YDB federation and dynamic/static provisioning integration coverage.
+2. Set-based bounded MERGE batches and benchmark instrumentation.
+3. MERGE transaction ownership, physical-primary-key update behavior, composite keys, and rollback/retry tests.
+4. Retry classification, driver-workaround audit, post-commit INSERT failure tests, and backpressure accounting.
+5. `hasBehavior` and inherited-override audit with focused negative tests.
+6. ARRAY/MAP/ROW mappings, followed by views/comments/column evolution as separate capability PRs.
+7. Packaging, security documentation, release validation, and final upstream-readiness review.
+
+No upstream Trino pull request is opened until every completed capability has passed its focused tests and the full `ydb-trino-adapter` suite.

--- a/ydb-trino-adapter/examples/trino/etc/catalog/ydb.properties
+++ b/ydb-trino-adapter/examples/trino/etc/catalog/ydb.properties
@@ -1,2 +1,4 @@
 connector.name=ydb
+# Local single-database example used by examples/docker-compose.yml.
+# Production uses one catalog file per database; see README for secret references.
 connection-url=jdbc:ydb:grpc://ydb-local:2136/local

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -45,6 +45,8 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.RelationColumnsMetadata;
+import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortOrder;
@@ -63,6 +65,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,6 +127,7 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Math.max;
 import static java.lang.String.format;
+import static java.sql.DatabaseMetaData.columnNoNulls;
 import static java.util.stream.Collectors.joining;
 
 public class YdbClient extends BaseJdbcClient {
@@ -265,6 +270,74 @@ public class YdbClient extends BaseJdbcClient {
                     .collect(Collectors.toList());
         } catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, "Failed to list YDB tables", e);
+        }
+    }
+
+    @Override
+    public List<RelationCommentMetadata> getAllTableComments(ConnectorSession session, Optional<String> schema) {
+        return getTableNames(session, schema).stream()
+                .map(table -> RelationCommentMetadata.forRelation(table, Optional.empty()))
+                .toList();
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema) {
+        if (schema.isPresent() && !DEFAULT_SCHEMA.equalsIgnoreCase(schema.get())) {
+            return ImmutableList.<RelationColumnsMetadata>of().iterator();
+        }
+
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            List<YdbTablePath> paths = listRemoteTablePaths(connection);
+            throwIfAmbiguous(paths);
+
+            Map<String, ImmutableList.Builder<ColumnMetadata>> columnsByTable = new LinkedHashMap<>();
+            paths.stream()
+                    .distinct()
+                    .forEach(path -> columnsByTable.put(path.value(), ImmutableList.builder()));
+
+            DatabaseMetaData metadata = connection.getMetaData();
+            try (ResultSet resultSet = metadata.getColumns(connection.getCatalog(), null, null, null)) {
+                while (resultSet.next()) {
+                    ImmutableList.Builder<ColumnMetadata> columns = columnsByTable.get(resultSet.getString("TABLE_NAME"));
+                    if (columns == null) {
+                        continue;
+                    }
+
+                    String columnName = resultSet.getString("COLUMN_NAME");
+                    JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                            getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                            Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                            getInteger(resultSet, "COLUMN_SIZE"),
+                            getInteger(resultSet, "DECIMAL_DIGITS"),
+                            Optional.empty(),
+                            Optional.empty());
+                    boolean nullable = resultSet.getInt("NULLABLE") != columnNoNulls;
+                    Optional<String> comment = Optional.ofNullable(resultSet.getString("REMARKS"))
+                            .filter(value -> !value.isEmpty());
+                    toColumnMapping(session, connection, typeHandle).ifPresent(mapping -> columns.add(
+                            JdbcColumnHandle.builder()
+                                    .setColumnName(columnName)
+                                    .setJdbcTypeHandle(typeHandle)
+                                    .setColumnType(mapping.getType())
+                                    .setNullable(nullable)
+                                    .setComment(comment)
+                                    .build()
+                                    .getColumnMetadata()));
+                }
+            }
+
+            ImmutableList.Builder<RelationColumnsMetadata> relations = ImmutableList.builder();
+            columnsByTable.forEach((table, columnsBuilder) -> {
+                List<ColumnMetadata> columns = columnsBuilder.build();
+                if (!columns.isEmpty()) {
+                    relations.add(RelationColumnsMetadata.forTable(
+                            new SchemaTableName(DEFAULT_SCHEMA, table),
+                            columns));
+                }
+            });
+            return relations.build().iterator();
+        } catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to list YDB table columns", e);
         }
     }
 

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -276,7 +276,7 @@ public class YdbClient extends BaseJdbcClient {
         if (!DEFAULT_SCHEMA.equalsIgnoreCase(schemaTableName.getSchemaName())) {
             return Optional.empty();
         }
-        if (schemaTableName.getTableName().endsWith("$data")) {
+        if (YdbTablePath.isDataSystemTableName(schemaTableName.getTableName())) {
             return Optional.empty();
         }
 

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -72,11 +72,13 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.jdbc.DefaultJdbcMetadata.MERGE_ROW_ID;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
@@ -316,7 +318,8 @@ public class YdbClient extends BaseJdbcClient {
         Map<String, Set<String>> valuesByComparisonKey = paths.stream()
                 .collect(Collectors.groupingBy(
                         YdbTablePath::comparisonKey,
-                        Collectors.mapping(YdbTablePath::value, Collectors.toSet())));
+                        TreeMap::new,
+                        Collectors.mapping(YdbTablePath::value, Collectors.toCollection(TreeSet::new))));
         valuesByComparisonKey.values().stream()
                 .filter(values -> values.size() > 1)
                 .findFirst()
@@ -606,13 +609,59 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     @Override
+    public JdbcOutputTableHandle beginInsertTable(
+            ConnectorSession session,
+            JdbcTableHandle tableHandle,
+            List<JdbcColumnHandle> columns)
+    {
+        verify(tableHandle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s", tableHandle);
+        RemoteTableName remoteTableName = tableHandle.asPlainTable().getRemoteTableName();
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            verify(connection.getAutoCommit());
+            String catalogName = remoteTableName.getCatalogName().isPresent()
+                    ? remoteTableName.getCatalogName().orElseThrow()
+                    : connection.getCatalog();
+            return beginInsertTable(
+                    session,
+                    connection,
+                    getRemoteIdentifiers(connection),
+                    catalogName,
+                    remoteTableName.getSchemaName().orElse(null),
+                    remoteTableName.getTableName(),
+                    columns);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
     public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName) {
-        YdbTablePath.fromUserInput(newTableName.getTableName());
+        YdbTablePath destination = YdbTablePath.fromUserInput(newTableName.getTableName());
         SchemaTableName currentName = handle.asPlainTable().getSchemaTableName();
         if (!currentName.getSchemaName().equalsIgnoreCase(newTableName.getSchemaName())) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
         }
-        super.renameTable(session, handle, newTableName);
+
+        verify(handle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s", handle);
+        RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            verify(connection.getAutoCommit());
+            String catalogName = remoteTableName.getCatalogName().isPresent()
+                    ? remoteTableName.getCatalogName().orElseThrow()
+                    : connection.getCatalog();
+            renameTable(
+                    session,
+                    connection,
+                    catalogName,
+                    remoteTableName.getSchemaName().orElse(null),
+                    remoteTableName.getTableName(),
+                    null,
+                    destination.value());
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -276,6 +276,9 @@ public class YdbClient extends BaseJdbcClient {
         if (!DEFAULT_SCHEMA.equalsIgnoreCase(schemaTableName.getSchemaName())) {
             return Optional.empty();
         }
+        if (schemaTableName.getTableName().endsWith("$data")) {
+            return Optional.empty();
+        }
 
         YdbTablePath requestedPath = YdbTablePath.fromUserInput(schemaTableName.getTableName());
         try (Connection connection = connectionFactory.openConnection(session)) {

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -55,7 +55,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import jakarta.annotation.Nullable;
-import org.jspecify.annotations.NonNull;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -106,6 +105,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.spi.StandardErrorCode.AMBIGUOUS_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -124,7 +124,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
 public class YdbClient extends BaseJdbcClient {
-    private static final String YDB_SCHEMA = "ydb";
+    static final String DEFAULT_SCHEMA = "default";
     private static final int YDB_DEFAULT_DECIMAL_PRECISION = 22;
     private static final int YDB_DEFAULT_DECIMAL_SCALE = 9;
 
@@ -240,7 +240,7 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public Collection<String> listSchemas(Connection connection) {
-        return ImmutableSet.of(YDB_SCHEMA);
+        return ImmutableSet.of(DEFAULT_SCHEMA);
     }
 
     @Override
@@ -250,17 +250,19 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public List<SchemaTableName> getTableNames(ConnectorSession session, Optional<String> schema) {
+        if (schema.isPresent() && !DEFAULT_SCHEMA.equalsIgnoreCase(schema.get())) {
+            return ImmutableList.of();
+        }
+
         try (Connection connection = connectionFactory.openConnection(session)) {
-            try (ResultSet resultSet = getTables(connection, Optional.empty(), Optional.empty())) {
-                ImmutableList.Builder<@NonNull SchemaTableName> list = ImmutableList.builder();
-                while (resultSet.next()) {
-                    String tableName = resultSet.getString("TABLE_NAME");
-                    list.add(new SchemaTableName(YDB_SCHEMA, tableName));
-                }
-                return list.build();
-            }
+            List<YdbTablePath> paths = listRemoteTablePaths(connection);
+            throwIfAmbiguous(paths);
+            return paths.stream()
+                    .distinct()
+                    .map(path -> new SchemaTableName(DEFAULT_SCHEMA, path.value()))
+                    .collect(Collectors.toList());
         } catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list YDB tables", e);
         }
     }
 
@@ -269,21 +271,58 @@ public class YdbClient extends BaseJdbcClient {
             ConnectorSession session,
             SchemaTableName schemaTableName
     ) {
-        try (Connection connection = connectionFactory.openConnection(session)) {
-            RemoteTableName remoteTableName = toRemoteTableName(schemaTableName);
-            try (ResultSet columns = getColumns(remoteTableName, connection.getMetaData())) {
-                if (!columns.next()) {
-                    return Optional.empty();
-                }
-            }
-            return Optional.of(new JdbcTableHandle(
-                    new SchemaTableName(YDB_SCHEMA, schemaTableName.getTableName()),
-                    remoteTableName,
-                    Optional.empty())
-            );
-        } catch (SQLException e) {
+        if (!DEFAULT_SCHEMA.equalsIgnoreCase(schemaTableName.getSchemaName())) {
             return Optional.empty();
         }
+
+        YdbTablePath requestedPath = YdbTablePath.fromUserInput(schemaTableName.getTableName());
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            return resolveRemoteTablePath(connection, requestedPath)
+                    .map(remotePath -> new JdbcTableHandle(
+                            new SchemaTableName(DEFAULT_SCHEMA, schemaTableName.getTableName()),
+                            new RemoteTableName(Optional.empty(), Optional.empty(), remotePath.value()),
+                            Optional.empty()));
+        } catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to resolve YDB table " + schemaTableName, e);
+        }
+    }
+
+    private List<YdbTablePath> listRemoteTablePaths(Connection connection)
+            throws SQLException
+    {
+        ImmutableList.Builder<YdbTablePath> paths = ImmutableList.builder();
+        try (ResultSet resultSet = getTables(connection, Optional.empty(), Optional.empty())) {
+            while (resultSet.next()) {
+                YdbTablePath.fromRemoteMetadata(resultSet.getString("TABLE_NAME"))
+                        .ifPresent(paths::add);
+            }
+        }
+        return paths.build();
+    }
+
+    private Optional<YdbTablePath> resolveRemoteTablePath(Connection connection, YdbTablePath requestedPath)
+            throws SQLException
+    {
+        List<YdbTablePath> matches = listRemoteTablePaths(connection).stream()
+                .filter(path -> path.comparisonKey().equals(requestedPath.comparisonKey()))
+                .distinct()
+                .toList();
+        throwIfAmbiguous(matches);
+        return matches.stream().findFirst();
+    }
+
+    private static void throwIfAmbiguous(List<YdbTablePath> paths)
+    {
+        Map<String, Set<String>> valuesByComparisonKey = paths.stream()
+                .collect(Collectors.groupingBy(
+                        YdbTablePath::comparisonKey,
+                        Collectors.mapping(YdbTablePath::value, Collectors.toSet())));
+        valuesByComparisonKey.values().stream()
+                .filter(values -> values.size() > 1)
+                .findFirst()
+                .ifPresent(values -> {
+                    throw new TrinoException(AMBIGUOUS_NAME, "Ambiguous YDB table path: " + values);
+                });
     }
 
     @Override
@@ -494,13 +533,14 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     private RemoteTableName toRemoteTableName(SchemaTableName schemaTableName) {
-        return new RemoteTableName(Optional.empty(), Optional.empty(), schemaTableName.getTableName());
+        String tableName = YdbTablePath.fromUserInput(schemaTableName.getTableName()).value();
+        return new RemoteTableName(Optional.empty(), Optional.empty(), tableName);
     }
 
     @Override
     protected String quoted(@Nullable String catalog, @Nullable String schema, String table) {
         // YDB doesn't use catalog & schema in table names, only the table path
-        return quoted(table);
+        return quoted(YdbTablePath.fromUserInput(table).value());
     }
 
     @Override
@@ -567,6 +607,7 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName) {
+        YdbTablePath.fromUserInput(newTableName.getTableName());
         SchemaTableName currentName = handle.asPlainTable().getSchemaTableName();
         if (!currentName.getSchemaName().equalsIgnoreCase(newTableName.getSchemaName())) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
@@ -648,7 +689,7 @@ public class YdbClient extends BaseJdbcClient {
         String tableName = remoteTableName.getTableName();
         String metadataSchemaName = remoteTableName.getSchemaName().orElse(null);
         SchemaTableName schemaTableName = new SchemaTableName(
-                remoteTableName.getSchemaName().orElse(YDB_SCHEMA),
+                remoteTableName.getSchemaName().orElse(DEFAULT_SCHEMA),
                 tableName);
         List<JdbcColumnHandle> columns = getColumnsForPrimaryKeyLookup(session, schemaTableName, remoteTableName);
         Map<String, JdbcColumnHandle> columnsByName = columns.stream()

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -626,7 +626,7 @@ public class YdbClient extends BaseJdbcClient {
                     connection,
                     getRemoteIdentifiers(connection),
                     catalogName,
-                    remoteTableName.getSchemaName().orElse(null),
+                    DEFAULT_SCHEMA,
                     remoteTableName.getTableName(),
                     columns);
         }

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -1,0 +1,88 @@
+package tech.ydb.trino;
+
+import io.trino.spi.TrinoException;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+
+record YdbTablePath(String value)
+{
+    private static final int MAX_COMPONENT_LENGTH = 255;
+    private static final Pattern COMPONENT = Pattern.compile("[A-Za-z0-9._-]+");
+
+    static YdbTablePath fromUserInput(String value)
+    {
+        return parseUserInput(value);
+    }
+
+    static Optional<YdbTablePath> fromRemoteMetadata(String value)
+    {
+        return parse(value, false);
+    }
+
+    String comparisonKey()
+    {
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    private static YdbTablePath parseUserInput(String value)
+    {
+        return parse(value, true).orElseThrow();
+    }
+
+    private static Optional<YdbTablePath> parse(String value, boolean userInput)
+    {
+        String pathError = validatePath(value);
+        if (pathError != null) {
+            throw invalidPath(value, pathError, userInput);
+        }
+
+        for (String component : value.split("/", -1)) {
+            if (component.startsWith(".")) {
+                if (!userInput) {
+                    return Optional.empty();
+                }
+                throw invalidPath(value, "components must not start with '.'", true);
+            }
+
+            String componentError = validateComponent(component);
+            if (componentError != null) {
+                throw invalidPath(value, componentError, userInput);
+            }
+        }
+        return Optional.of(new YdbTablePath(value));
+    }
+
+    private static String validatePath(String value)
+    {
+        if (value == null) {
+            return "path must not be null";
+        }
+        return null;
+    }
+
+    private static String validateComponent(String component)
+    {
+        if (component.isEmpty()) {
+            return "components must not be empty";
+        }
+        if (component.length() > MAX_COMPONENT_LENGTH) {
+            return "components must be at most " + MAX_COMPONENT_LENGTH + " characters";
+        }
+        if (!COMPONENT.matcher(component).matches()) {
+            return "components may contain only letters, digits, '.', '_' and '-'";
+        }
+        return null;
+    }
+
+    private static TrinoException invalidPath(String value, String reason, boolean userInput)
+    {
+        return new TrinoException(
+                userInput ? INVALID_ARGUMENTS : JDBC_ERROR,
+                "Invalid YDB table path '" + value + "': " + reason);
+    }
+}

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -27,11 +27,15 @@ record YdbTablePath(String value)
 
     static boolean isDataSystemTableName(String value)
     {
-        if (value == null || value.length() > MAX_COMPONENT_LENGTH || !value.endsWith(DATA_SYSTEM_TABLE_SUFFIX)) {
+        if (value == null || !value.endsWith(DATA_SYSTEM_TABLE_SUFFIX)) {
+            return false;
+        }
+        String tablePath = value.substring(0, value.length() - DATA_SYSTEM_TABLE_SUFFIX.length());
+        if (tablePath.isEmpty()) {
             return false;
         }
         try {
-            fromUserInput(value.substring(0, value.length() - DATA_SYSTEM_TABLE_SUFFIX.length()));
+            fromUserInput(tablePath);
             return true;
         } catch (TrinoException e) {
             return false;
@@ -51,7 +55,7 @@ record YdbTablePath(String value)
     private static Optional<YdbTablePath> parse(String value, boolean userInput)
     {
         if (value == null) {
-            throw invalidPath(value, validatePath(value), userInput);
+            throw invalidPath(value, "path must not be null", userInput);
         }
 
         String[] components = value.split("/", -1);
@@ -61,11 +65,6 @@ record YdbTablePath(String value)
                     return Optional.empty();
                 }
             }
-        }
-
-        String pathError = validatePath(value);
-        if (pathError != null) {
-            throw invalidPath(value, pathError, userInput);
         }
 
         for (String component : components) {
@@ -79,17 +78,6 @@ record YdbTablePath(String value)
             }
         }
         return Optional.of(new YdbTablePath(value));
-    }
-
-    private static String validatePath(String value)
-    {
-        if (value == null) {
-            return "path must not be null";
-        }
-        if (value.length() > MAX_COMPONENT_LENGTH) {
-            return "path is too long; must be at most " + MAX_COMPONENT_LENGTH + " characters";
-        }
-        return null;
     }
 
     private static String validateComponent(String component)

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -12,6 +12,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 record YdbTablePath(String value)
 {
     private static final int MAX_COMPONENT_LENGTH = 255;
+    private static final String DATA_SYSTEM_TABLE_SUFFIX = "$data";
     private static final Pattern COMPONENT = Pattern.compile("[A-Za-z0-9._-]+");
 
     static YdbTablePath fromUserInput(String value)
@@ -22,6 +23,19 @@ record YdbTablePath(String value)
     static Optional<YdbTablePath> fromRemoteMetadata(String value)
     {
         return parse(value, false);
+    }
+
+    static boolean isDataSystemTableName(String value)
+    {
+        if (value == null || value.length() > MAX_COMPONENT_LENGTH || !value.endsWith(DATA_SYSTEM_TABLE_SUFFIX)) {
+            return false;
+        }
+        try {
+            fromUserInput(value.substring(0, value.length() - DATA_SYSTEM_TABLE_SUFFIX.length()));
+            return true;
+        } catch (TrinoException e) {
+            return false;
+        }
     }
 
     String comparisonKey()

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -36,16 +36,26 @@ record YdbTablePath(String value)
 
     private static Optional<YdbTablePath> parse(String value, boolean userInput)
     {
+        if (value == null) {
+            throw invalidPath(value, validatePath(value), userInput);
+        }
+
+        String[] components = value.split("/", -1);
+        if (!userInput) {
+            for (String component : components) {
+                if (component.startsWith(".")) {
+                    return Optional.empty();
+                }
+            }
+        }
+
         String pathError = validatePath(value);
         if (pathError != null) {
             throw invalidPath(value, pathError, userInput);
         }
 
-        for (String component : value.split("/", -1)) {
+        for (String component : components) {
             if (component.startsWith(".")) {
-                if (!userInput) {
-                    return Optional.empty();
-                }
                 throw invalidPath(value, "components must not start with '.'", true);
             }
 

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -62,6 +62,9 @@ record YdbTablePath(String value)
         if (value == null) {
             return "path must not be null";
         }
+        if (value.length() > MAX_COMPONENT_LENGTH) {
+            return "path must be at most " + MAX_COMPONENT_LENGTH + " characters";
+        }
         return null;
     }
 

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -73,7 +73,7 @@ record YdbTablePath(String value)
             return "path must not be null";
         }
         if (value.length() > MAX_COMPONENT_LENGTH) {
-            return "path must be at most " + MAX_COMPONENT_LENGTH + " characters";
+            return "path is too long; must be at most " + MAX_COMPONENT_LENGTH + " characters";
         }
         return null;
     }
@@ -84,7 +84,7 @@ record YdbTablePath(String value)
             return "components must not be empty";
         }
         if (component.length() > MAX_COMPONENT_LENGTH) {
-            return "components must be at most " + MAX_COMPONENT_LENGTH + " characters";
+            return "components are too long; must be at most " + MAX_COMPONENT_LENGTH + " characters";
         }
         if (!COMPONENT.matcher(component).matches()) {
             return "components may contain only letters, digits, '.', '_' and '-'";

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -43,22 +43,19 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     }
 
     @Test
-    public void testNestedTablePath() {
+    public void testNestedTablePath() throws Exception {
         String namespace = "namespace_" + uniqueSuffix();
         String directory = namespace + "/eu";
         String table = directory + "/orders";
 
         createDirectory(directory);
-        try {
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
             assertQuerySucceeds("CREATE TABLE \"" + table + "\" (id bigint NOT NULL)");
             assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(table);
             assertQueryReturnsEmptyResult("SELECT id FROM \"" + table + "\"");
             assertThat(computeScalar("SHOW CREATE TABLE \"" + table + "\"").toString()).contains(table);
-        }
-        finally {
-            assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"");
-            removeDirectory(directory);
-            removeDirectory(namespace);
         }
     }
 
@@ -70,63 +67,46 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     }
 
     @Test
-    public void testCaseOnlyTablePathAmbiguity() throws SQLException {
+    public void testCaseOnlyTablePathAmbiguity() throws Exception {
         String suffix = uniqueSuffix();
         String firstDirectory = "Case_" + suffix;
         String secondDirectory = "case_" + suffix;
         String firstTable = firstDirectory + "/Orders";
         String secondTable = secondDirectory + "/orders";
-        boolean firstTableCreated = false;
-        boolean secondTableCreated = false;
 
         createDirectory(firstDirectory);
-        createDirectory(secondDirectory);
-        try {
-            createRawTable(firstTable);
-            firstTableCreated = true;
-            createRawTable(secondTable);
-            secondTableCreated = true;
-
-            assertQueryFails(
-                    "SELECT * FROM \"" + secondTable + "\"",
-                    ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
-        }
-        finally {
-            if (secondTableCreated) {
-                dropRawTable(secondTable);
+        try (AutoCloseable ignoredFirstDirectory = () -> removeDirectory(firstDirectory)) {
+            createDirectory(secondDirectory);
+            try (AutoCloseable ignoredSecondDirectory = () -> removeDirectory(secondDirectory)) {
+                createRawTable(firstTable);
+                try (AutoCloseable ignoredFirstTable = () -> dropRawTable(firstTable)) {
+                    createRawTable(secondTable);
+                    try (AutoCloseable ignoredSecondTable = () -> dropRawTable(secondTable)) {
+                        assertQueryFails(
+                                "SELECT * FROM \"" + secondTable + "\"",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                    }
+                }
             }
-            if (firstTableCreated) {
-                dropRawTable(firstTable);
-            }
-            removeDirectory(secondDirectory);
-            removeDirectory(firstDirectory);
         }
     }
 
     @Test
-    public void testUniqueCaseTableWriteLifecycle() throws SQLException {
+    public void testUniqueCaseTableWriteLifecycle() throws Exception {
         String suffix = uniqueSuffix();
         String remoteTable = "MixedCase_" + suffix;
         String logicalTable = remoteTable.toLowerCase(java.util.Locale.ROOT);
         String renamedTable = "renamed_" + suffix;
-        boolean tableCreated = false;
-        boolean tableRenamed = false;
 
-        try {
+        try (AutoCloseable ignoredOriginalTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + logicalTable + "\"");
+                AutoCloseable ignoredRenamedTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + renamedTable + "\"")) {
             createRawTable(remoteTable);
-            tableCreated = true;
 
             assertUpdate("INSERT INTO \"" + logicalTable + "\" VALUES (1)", 1);
             assertQuerySucceeds("ALTER TABLE \"" + logicalTable + "\" RENAME TO \"" + renamedTable + "\"");
-            tableRenamed = true;
 
             assertQuery("SELECT id FROM \"" + renamedTable + "\"", "VALUES CAST(1 AS BIGINT)");
             assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(renamedTable);
-        }
-        finally {
-            if (tableCreated) {
-                dropRawTable(tableRenamed ? renamedTable : remoteTable);
-            }
         }
     }
 

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -6,10 +6,17 @@ import io.trino.testing.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import tech.ydb.scheme.SchemeClient;
 import tech.ydb.test.junit5.YdbHelperExtension;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,6 +40,124 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         assertThat(computeActual("SHOW TABLES FROM ydb.default").getOnlyColumnAsSet())
                 .contains("orders");
         assertQueryFails("SELECT * FROM ydb.missing.orders", ".*Schema 'missing' does not exist");
+    }
+
+    @Test
+    public void testNestedTablePath() {
+        String namespace = "namespace_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+
+        createDirectory(directory);
+        try {
+            assertQuerySucceeds("CREATE TABLE \"" + table + "\" (id bigint NOT NULL)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(table);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + table + "\"");
+            assertThat(computeScalar("SHOW CREATE TABLE \"" + table + "\"").toString()).contains(table);
+        }
+        finally {
+            assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"");
+            removeDirectory(directory);
+            removeDirectory(namespace);
+        }
+    }
+
+    @Test
+    public void testInvalidTablePaths() {
+        for (String table : List.of("/orders", "a//orders", "a/../orders", ".sys/orders")) {
+            assertQueryFails("SELECT * FROM ydb.default.\"" + table + "\"", ".*Invalid YDB table path.*");
+        }
+    }
+
+    @Test
+    public void testCaseOnlyTablePathAmbiguity() throws SQLException {
+        String suffix = uniqueSuffix();
+        String firstDirectory = "Case_" + suffix;
+        String secondDirectory = "case_" + suffix;
+        String firstTable = firstDirectory + "/Orders";
+        String secondTable = secondDirectory + "/orders";
+        boolean firstTableCreated = false;
+        boolean secondTableCreated = false;
+
+        createDirectory(firstDirectory);
+        createDirectory(secondDirectory);
+        try {
+            createRawTable(firstTable);
+            firstTableCreated = true;
+            createRawTable(secondTable);
+            secondTableCreated = true;
+
+            assertQueryFails(
+                    "SELECT * FROM \"" + secondTable + "\"",
+                    ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+        }
+        finally {
+            if (secondTableCreated) {
+                dropRawTable(secondTable);
+            }
+            if (firstTableCreated) {
+                dropRawTable(firstTable);
+            }
+            removeDirectory(secondDirectory);
+            removeDirectory(firstDirectory);
+        }
+    }
+
+    @Test
+    public void testUniqueCaseTableWriteLifecycle() throws SQLException {
+        String suffix = uniqueSuffix();
+        String remoteTable = "MixedCase_" + suffix;
+        String logicalTable = remoteTable.toLowerCase(java.util.Locale.ROOT);
+        String renamedTable = "renamed_" + suffix;
+        boolean tableCreated = false;
+        boolean tableRenamed = false;
+
+        try {
+            createRawTable(remoteTable);
+            tableCreated = true;
+
+            assertUpdate("INSERT INTO \"" + logicalTable + "\" VALUES (1)", 1);
+            assertQuerySucceeds("ALTER TABLE \"" + logicalTable + "\" RENAME TO \"" + renamedTable + "\"");
+            tableRenamed = true;
+
+            assertQuery("SELECT id FROM \"" + renamedTable + "\"", "VALUES CAST(1 AS BIGINT)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(renamedTable);
+        }
+        finally {
+            if (tableCreated) {
+                dropRawTable(tableRenamed ? renamedTable : remoteTable);
+            }
+        }
+    }
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static void createDirectory(String relativePath) {
+        try (SchemeClient client = SchemeClient.newClient(ydb.createTransport()).build()) {
+            client.makeDirectories(ydb.database() + "/" + relativePath).join().expectSuccess();
+        }
+    }
+
+    private static void removeDirectory(String relativePath) {
+        try (SchemeClient client = SchemeClient.newClient(ydb.createTransport()).build()) {
+            client.removeDirectory(ydb.database() + "/" + relativePath).join().expectSuccess();
+        }
+    }
+
+    private static void createRawTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` (id Int64 NOT NULL, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void dropRawTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE `" + remoteTable + "`");
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -19,6 +19,7 @@ import java.util.OptionalInt;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestYdbConnectorTest extends BaseConnectorTest {
 
@@ -260,6 +261,38 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     @Override
     protected OptionalInt maxColumnNameLength() {
         return OptionalInt.of(255);
+    }
+
+    @Test
+    @Override
+    public void testRenameTableToLongTableName() {
+        skipTestUnless(hasBehavior(TestingConnectorBehavior.SUPPORTS_RENAME_TABLE));
+
+        String sourceTableName = "test_rename_source_" + uniqueSuffix();
+        String baseTableName = "test_rename_target_" + uniqueSuffix();
+        int maxLength = maxTableRenameLength().orElseThrow();
+        String validTargetTableName = baseTableName + "z".repeat(maxLength - baseTableName.length());
+        String invalidTargetTableName = validTargetTableName + "z";
+
+        try {
+            assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
+            assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + validTargetTableName);
+            assertThat(getQueryRunner().tableExists(getSession(), validTargetTableName)).isTrue();
+            assertQuery("SELECT x FROM " + validTargetTableName, "VALUES 123");
+            assertUpdate("DROP TABLE " + validTargetTableName);
+
+            assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
+            assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + invalidTargetTableName))
+                    .satisfies(this::verifyTableNameLengthFailurePermissible);
+            assertThat(getQueryRunner().tableExists(getSession(), sourceTableName)).isTrue();
+            assertQuery("SELECT x FROM " + sourceTableName, "VALUES 123");
+
+            // Trino 479 expects tableExists(invalidTarget) to be false, but this lookup returns INVALID_ARGUMENTS.
+            assertQueryFails("SELECT x FROM " + invalidTargetTableName, ".*Invalid YDB table path.*too long.*");
+        } finally {
+            assertQuerySucceeds("DROP TABLE IF EXISTS " + validTargetTableName);
+            assertQuerySucceeds("DROP TABLE IF EXISTS " + sourceTableName);
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -25,6 +25,16 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                 .build();
     }
 
+    @Test
+    public void testDefaultSchemaContract() {
+        assertThat(computeActual("SHOW SCHEMAS FROM ydb").getOnlyColumnAsSet())
+                .contains("default")
+                .doesNotContain("ydb");
+        assertThat(computeActual("SHOW TABLES FROM ydb.default").getOnlyColumnAsSet())
+                .contains("orders");
+        assertQueryFails("SELECT * FROM ydb.missing.orders", "Schema missing not found");
+    }
+
     @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior) {
         return switch (connectorBehavior) {

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -32,7 +32,7 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                 .doesNotContain("ydb");
         assertThat(computeActual("SHOW TABLES FROM ydb.default").getOnlyColumnAsSet())
                 .contains("orders");
-        assertQueryFails("SELECT * FROM ydb.missing.orders", "Schema missing not found");
+        assertQueryFails("SELECT * FROM ydb.missing.orders", ".*Schema 'missing' does not exist");
     }
 
     @Override

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -1,5 +1,6 @@
 package tech.ydb.trino;
 
+import io.trino.Session;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.testing.*;
@@ -61,6 +62,85 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     }
 
     @Test
+    public void testNestedTablePathLongerThanSingleComponentLimit() throws Exception {
+        String suffix = uniqueSuffix();
+        String parent = "long_" + "a".repeat(130) + suffix;
+        String directory = parent + "/branch_" + "b".repeat(90);
+        String sourceTable = directory + "/source_" + suffix;
+        String renamedTable = directory + "/renamed_" + suffix;
+
+        assertThat(sourceTable.length()).isGreaterThan(255);
+        createDirectory(directory);
+        try (AutoCloseable ignoredParent = () -> removeDirectory(parent);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredSourceTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + sourceTable + "\"");
+                AutoCloseable ignoredRenamedTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + renamedTable + "\"")) {
+            assertQuerySucceeds("CREATE TABLE \"" + sourceTable + "\" (id bigint NOT NULL)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(sourceTable);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + sourceTable + "\"");
+
+            assertQuerySucceeds("ALTER TABLE \"" + sourceTable + "\" RENAME TO \"" + renamedTable + "\"");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                    .contains(renamedTable)
+                    .doesNotContain(sourceTable);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + renamedTable + "\"");
+        }
+    }
+
+    @Test
+    public void testDefaultSchemaRelationComments() throws Exception {
+        String namespace = "comments_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+
+        createDirectory(directory);
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
+            assertQuerySucceeds("CREATE TABLE \"" + table + "\" (id bigint NOT NULL)");
+
+            assertThat(query(
+                    "SELECT schema_name, table_name, comment " +
+                            "FROM system.metadata.table_comments " +
+                            "WHERE catalog_name = 'ydb' AND schema_name = 'default'"))
+                    .skippingTypesCheck()
+                    .containsAll("VALUES ('default', '" + table + "', null)");
+            assertQueryReturnsEmptyResult(
+                    "SELECT table_name FROM system.metadata.table_comments " +
+                            "WHERE catalog_name = 'ydb' AND schema_name = 'missing'");
+        }
+    }
+
+    @Test
+    public void testDefaultSchemaBulkColumns() throws Exception {
+        String namespace = "columns_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+        Session bulkSession = Session.builder(getSession())
+                .setCatalogSessionProperty("ydb", "bulk_list_columns", "true")
+                .build();
+
+        createDirectory(directory);
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
+            createRawMetadataTable(table);
+
+            assertQuery(
+                    bulkSession,
+                    "SELECT column_name, data_type, is_nullable " +
+                            "FROM information_schema.columns " +
+                            "WHERE table_schema = 'default' AND table_name = '" + table + "' " +
+                            "ORDER BY ordinal_position",
+                    "VALUES ('id', 'bigint', 'NO'), ('note', 'varchar', 'YES')");
+            assertQueryReturnsEmptyResult(
+                    bulkSession,
+                    "SELECT column_name FROM information_schema.columns " +
+                            "WHERE table_schema = 'missing' AND table_name = '" + table + "'");
+        }
+    }
+
+    @Test
     public void testInvalidTablePaths() {
         for (String table : List.of("/orders", "a//orders", "a/../orders", ".sys/orders")) {
             assertQueryFails("SELECT * FROM ydb.default.\"" + table + "\"", ".*Invalid YDB table path.*");
@@ -85,6 +165,17 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                     try (AutoCloseable ignoredSecondTable = () -> dropRawTable(secondTable)) {
                         assertQueryFails(
                                 "SELECT * FROM \"" + secondTable + "\"",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                        Session bulkSession = Session.builder(getSession())
+                                .setCatalogSessionProperty("ydb", "bulk_list_columns", "true")
+                                .build();
+                        assertQueryFails(
+                                bulkSession,
+                                "SELECT table_name FROM information_schema.columns WHERE table_schema = 'default'",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                        assertQueryFails(
+                                "SELECT table_name FROM system.metadata.table_comments " +
+                                        "WHERE catalog_name = 'ydb' AND schema_name = 'default'",
                                 ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
                     }
                 }
@@ -131,6 +222,14 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
                 Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE `" + remoteTable + "` (id Int64 NOT NULL, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void createRawMetadataTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` " +
+                    "(id Int64 NOT NULL, note Utf8, PRIMARY KEY (id))");
         }
     }
 

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -33,7 +33,10 @@ class TestYdbTablePath
     @Test
     void testComponentLength()
     {
+        String nestedPath = "a".repeat(127) + "/" + "b".repeat(128);
+
         assertThat(YdbTablePath.fromUserInput("a".repeat(255)).value()).hasSize(255);
+        assertThat(YdbTablePath.fromUserInput(nestedPath).value()).isEqualTo(nestedPath);
 
         assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
                 .isInstanceOf(TrinoException.class)
@@ -42,19 +45,17 @@ class TestYdbTablePath
 
         assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
                 .hasMessageContaining("too long");
-
-        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(127) + "/" + "b".repeat(128)))
-                .isInstanceOf(TrinoException.class)
-                .extracting(exception -> ((TrinoException) exception).getErrorCode())
-                .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
     }
 
     @Test
     void testDataSystemTableName()
     {
         assertThat(YdbTablePath.isDataSystemTableName("nation$data")).isTrue();
+        assertThat(YdbTablePath.isDataSystemTableName("a".repeat(255) + "$data")).isTrue();
+        assertThat(YdbTablePath.isDataSystemTableName(
+                "a".repeat(127) + "/" + "b".repeat(128) + "$data")).isTrue();
 
-        for (String path : new String[] {"$data", "a/$data", "a$bad$data", "a".repeat(251) + "$data"}) {
+        for (String path : new String[] {"$data", "a/$data", "a$bad$data", "a".repeat(256) + "$data"}) {
             assertThat(YdbTablePath.isDataSystemTableName(path)).isFalse();
             assertThatThrownBy(() -> YdbTablePath.fromUserInput(path))
                     .isInstanceOf(TrinoException.class)
@@ -66,10 +67,18 @@ class TestYdbTablePath
     @Test
     void testRemoteMetadataPaths()
     {
+        String nestedPath = "a".repeat(127) + "/" + "b".repeat(128);
+
         assertThat(YdbTablePath.fromRemoteMetadata(".sys/table")).isEmpty();
         assertThat(YdbTablePath.fromRemoteMetadata(".sys/" + "a".repeat(251))).isEmpty();
+        assertThat(YdbTablePath.fromRemoteMetadata(nestedPath)).contains(new YdbTablePath(nestedPath));
 
         assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/$/b"))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(JDBC_ERROR.toErrorCode());
+
+        assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/" + "b".repeat(256)))
                 .isInstanceOf(TrinoException.class)
                 .extracting(exception -> ((TrinoException) exception).getErrorCode())
                 .isEqualTo(JDBC_ERROR.toErrorCode());

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -50,6 +50,20 @@ class TestYdbTablePath
     }
 
     @Test
+    void testDataSystemTableName()
+    {
+        assertThat(YdbTablePath.isDataSystemTableName("nation$data")).isTrue();
+
+        for (String path : new String[] {"$data", "a/$data", "a$bad$data", "a".repeat(251) + "$data"}) {
+            assertThat(YdbTablePath.isDataSystemTableName(path)).isFalse();
+            assertThatThrownBy(() -> YdbTablePath.fromUserInput(path))
+                    .isInstanceOf(TrinoException.class)
+                    .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                    .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+        }
+    }
+
+    @Test
     void testRemoteMetadataPaths()
     {
         assertThat(YdbTablePath.fromRemoteMetadata(".sys/table")).isEmpty();

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -50,6 +50,7 @@ class TestYdbTablePath
     void testRemoteMetadataPaths()
     {
         assertThat(YdbTablePath.fromRemoteMetadata(".sys/table")).isEmpty();
+        assertThat(YdbTablePath.fromRemoteMetadata(".sys/" + "a".repeat(251))).isEmpty();
 
         assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/$/b"))
                 .isInstanceOf(TrinoException.class)

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -1,0 +1,54 @@
+package tech.ydb.trino;
+
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestYdbTablePath
+{
+    @Test
+    void testValidUserPaths()
+    {
+        assertThat(YdbTablePath.fromUserInput("orders").value()).isEqualTo("orders");
+        assertThat(YdbTablePath.fromUserInput("sales/eu/orders").value()).isEqualTo("sales/eu/orders");
+        assertThat(YdbTablePath.fromUserInput("sales.eu/orders-v2").comparisonKey())
+                .isEqualTo("sales.eu/orders-v2");
+    }
+
+    @Test
+    void testInvalidUserPaths()
+    {
+        for (String path : new String[] {"", "/orders", "orders/", "a//b", ".", "..", "a/../b", ".sys/table", "a/$/b"}) {
+            assertThatThrownBy(() -> YdbTablePath.fromUserInput(path))
+                    .isInstanceOf(TrinoException.class)
+                    .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                    .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+        }
+    }
+
+    @Test
+    void testComponentLength()
+    {
+        assertThat(YdbTablePath.fromUserInput("a".repeat(255)).value()).hasSize(255);
+
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+    }
+
+    @Test
+    void testRemoteMetadataPaths()
+    {
+        assertThat(YdbTablePath.fromRemoteMetadata(".sys/table")).isEmpty();
+
+        assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/$/b"))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(JDBC_ERROR.toErrorCode());
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -40,6 +40,9 @@ class TestYdbTablePath
                 .extracting(exception -> ((TrinoException) exception).getErrorCode())
                 .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
 
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
+                .hasMessageContaining("too long");
+
         assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(127) + "/" + "b".repeat(128)))
                 .isInstanceOf(TrinoException.class)
                 .extracting(exception -> ((TrinoException) exception).getErrorCode())

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -39,6 +39,11 @@ class TestYdbTablePath
                 .isInstanceOf(TrinoException.class)
                 .extracting(exception -> ((TrinoException) exception).getErrorCode())
                 .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(127) + "/" + "b".repeat(128)))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
     }
 
     @Test

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class YdbQueryRunner {
-    public static final String TPCH_SCHEMA = "ydb";
+    public static final String TPCH_SCHEMA = YdbClient.DEFAULT_SCHEMA;
     public static final String YDB_HIDDEN_PK_COLUMN = TestingYdbJdbcClient.YDB_HIDDEN_PK_COLUMN;
 
     private YdbQueryRunner() {}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class YdbQueryRunner {
-    public static final String TPCH_SCHEMA = YdbClient.DEFAULT_SCHEMA;
+    public static final String DEFAULT_SCHEMA = YdbClient.DEFAULT_SCHEMA;
     public static final String YDB_HIDDEN_PK_COLUMN = TestingYdbJdbcClient.YDB_HIDDEN_PK_COLUMN;
 
     private YdbQueryRunner() {}
@@ -32,7 +32,7 @@ public final class YdbQueryRunner {
                 .addConnectorProperty("connection-url", jdbcUrl);
     }
 
-    private static String buildJdbcUrl(YdbHelperExtension ydb) {
+    static String buildJdbcUrl(YdbHelperExtension ydb) {
         StringBuilder url = new StringBuilder("jdbc:ydb:");
         url.append(ydb.useTls() ? "grpcs://" : "grpc://");
         url.append(ydb.endpoint());
@@ -51,7 +51,7 @@ public final class YdbQueryRunner {
         private Builder() {
             super(testSessionBuilder()
                     .setCatalog("ydb")
-                    .setSchema(TPCH_SCHEMA)
+                    .setSchema(DEFAULT_SCHEMA)
                     .build());
         }
 


### PR DESCRIPTION
## Summary

- expose one virtual `default` Trino schema for each statically configured YDB database catalog
- map the complete relative YDB directory path to one quoted table name with strict per-component validation and deterministic case-collision handling
- make recursive table, relation-comment, and opt-in bulk-column metadata preserve the real remote path
- document catalog provisioning, path quoting, secret handling, and current federation/transaction limits

## Verification

- JDK 25 compile: passed
- focused path, metadata, long-name, `$data`, and inherited information-schema regressions: 14 run, 0 failures, 0 errors, 0 skipped
- CI-equivalent `mvn --batch-mode --update-snapshots -f ydb-trino-adapter/pom.xml clean test`: 327 run, 0 failures, 0 errors, 84 skipped; 243 executed tests passed
  - `TestYdbTablePath`: 5 / 0 / 0 / 0
  - `TestYdbConnectorTest`: 286 / 0 / 0 / 80
  - `TestYdbConnectorSmokeTest`: 36 / 0 / 0 / 4

## Deliberate limits

- schema DDL capabilities remain disabled
- two-catalog YDB federation is documented but not yet integration-tested; it is the next independent slice
- preexisting inherited-test overrides remain tracked as P2 debt in `ROADMAP.md`

Context: https://github.com/trinodb/trino/issues/28110