### PR TITLE
Reject YDB physical primary-key updates

### DIFF
--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -182,9 +182,9 @@ blank `query.comment-format` preserves batching; a configured remote-query
 comment has not yet been verified.
 
 1. The focused MERGE contract test now uses a composite metadata primary key,
-   a non-key leading visible column, and a sibling row whose individual key
-   components collide with the UPDATE and DELETE targets. It verifies that
-   both operations address the complete physical key while
+   a non-key leading visible column, and two cross-sibling rows covering both
+   individual key components of the UPDATE and DELETE targets. It verifies
+   that both operations address the complete physical key while
    update/delete/insert branches coexist.
 2. Preserve the implemented transaction invariants: each attempt opens one
    connection, sets `autoCommit=false`, executes all operation groups, and
@@ -211,18 +211,14 @@ retries after uncertain commit outcomes.
 
 ### Merge-key slice validation (2026-08-20)
 
-Before the composite-key fixture was strengthened with sibling rows, the two
-focused physical-key tests passed 2/2; four targeted inherited MERGE tests
-passed 4/4; the two affected smoke tests passed 2/2; and isolated
-`testMergeLarge` passed 1/1. The strengthened focused test still requires a
-fresh Docker-backed rerun.
-
-The first CI-equivalent full run reported 335 tests, 0 failures, 1 error, and
-84 skipped. The sole `testMergeLarge` error occurred during its prerequisite
-TPCH `INSERT ... SELECT`, before MERGE execution; its isolated rerun passed. A
-second clean full run did not complete because the Docker daemon became
-unresponsive and its YDB Testcontainer disappeared. Therefore this slice does
-not yet have a green full-suite result.
+GitHub Actions run
+[`32378003537`](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32378003537)
+at `33bfb8f` reported 338 tests, 0 failures, 0 errors, and 84 skipped. It
+included Connector 288/80, Smoke 36/4, Federation 6/0, TablePath 5/0, and the
+port allocator 3/0. That run verified the physical-key rejection contract and
+the initial cross-sibling fixture. Final review added the complementary
+cross-sibling needed to catch either operation using either individual key;
+the required GitHub Actions check on PR #244 gates that final test-only change.
 
 ## P1 — retry and transaction hardening
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -154,26 +154,69 @@ This verifies the stated connector behavior only. It does not provide a shared
 snapshot or distributed commit, and it makes no production configuration or
 capability declaration changes.
 
-## P0 — harden MERGE scalability and atomicity
+## P0 — validate the JDBC batch/key contract and bound MERGE resources
 
-1. Replace row-by-row prepared-statement execution in `YdbMergeSink` with a
-   set-based YQL path. Candidate primitives are
-   [`UPDATE ... ON`](https://ydb.tech/docs/en/yql/reference/syntax/update) and
-   [`AS_TABLE`](https://ydb.tech/docs/en/yql/reference/syntax/select/from_as_table),
-   using bounded batches of typed list-of-struct parameters.
-2. Preserve one logical MERGE transaction. Until a staging/finalize design is
-   implemented, keep one writer task and reject Trino query/task retries for a
-   direct-to-target merge.
-3. YQL `UPDATE` cannot change a primary-key value. Implement physical-key
-   changes as atomic delete+insert row changes, or reject that statement with a
-   documented `NOT_SUPPORTED` error. See the
+`YdbMergeSink` already calls JDBC `addBatch()` for DELETE, UPDATE, and INSERT.
+Source inspection of the pinned YDB JDBC 2.3.18 driver shows that, with its
+default prepare/auto-batch settings, each eligible non-empty `executeBatch()`
+is represented as one typed `List<Struct>` parameter and one set-based YQL
+request. The generated forms use
+[`UPDATE ... ON`](https://ydb.tech/docs/en/yql/reference/syntax/update),
+`DELETE ... ON`, or `INSERT ... SELECT` over
+[`AS_TABLE($batch)`](https://ydb.tech/docs/en/yql/reference/syntax/select/from_as_table).
+This is driver-owned batching; the connector must not duplicate that rewrite.
+This request cardinality is source-derived; the current connector tests do not
+instrument or count remote requests.
+
+The rewrite requires the simple SQL shape recognized by the driver's
+`YqlBatcher`, complete primary-key equality for UPDATE/DELETE,
+`disablePrepareDataQuery=false`, `disableAutoPreparedBatches=false`, and no
+query modifier that changes the recognized shape. In particular, the default
+blank `query.comment-format` preserves batching; a configured remote-query
+comment has not yet been verified.
+
+1. The focused MERGE contract test now uses a composite metadata primary key,
+   a non-key leading visible column, and a sibling row whose individual key
+   components collide with the UPDATE and DELETE targets. It verifies that
+   both operations address the complete physical key while
+   update/delete/insert branches coexist.
+2. Preserve the implemented transaction invariants: each attempt opens one
+   connection, sets `autoCommit=false`, executes all operation groups, and
+   commits once; write parallelism is limited to one and Trino query/task retry
+   modes are rejected. Each connector retry opens fresh transactional state.
+   Failure-after-commit behavior is not yet proven, so no at-most-once replay
+   claim is made without an operation-id or staging/finalize design.
+3. Direct UPDATE and MERGE now reject physical primary-key changes before
+   remote mutation with `NOT_SUPPORTED`. Atomic delete+insert remains a
+   possible future extension. See the
    [YQL UPDATE contract](https://ydb.tech/docs/en/yql/reference/syntax/update).
-4. Add focused tests for composite primary keys, a non-unique first visible
-   column, physical-key updates, rollback/close, and fresh-state retries.
+4. Define and test page/request memory limits. The connector retains all input
+   pages until `finish()`, then creates operation-specific pages while the
+   driver retains the corresponding row structs and list parameter. No current
+   bounded-memory or maximum-request-size claim is made.
+5. Extend rollback/close and fresh-state retry tests, including an uncertain
+   commit outcome that must not replay an already committed change.
 
-**Exit criterion:** retain the current green inherited `testMerge*` suite and
-add a bounded-memory benchmark that demonstrates acceptable production-scale
-runtime for the set-based implementation.
+**Exit criterion:** retain the green inherited `testMerge*` suite, cover the
+physical composite-key and rejection contracts, and demonstrate the chosen
+page/request limits with a bounded-memory production-scale benchmark. A safe
+staging/finalize or operation-id design is required before claiming replay-safe
+retries after uncertain commit outcomes.
+
+### Merge-key slice validation (2026-08-20)
+
+Before the composite-key fixture was strengthened with sibling rows, the two
+focused physical-key tests passed 2/2; four targeted inherited MERGE tests
+passed 4/4; the two affected smoke tests passed 2/2; and isolated
+`testMergeLarge` passed 1/1. The strengthened focused test still requires a
+fresh Docker-backed rerun.
+
+The first CI-equivalent full run reported 335 tests, 0 failures, 1 error, and
+84 skipped. The sole `testMergeLarge` error occurred during its prerequisite
+TPCH `INSERT ... SELECT`, before MERGE execution; its isolated rerun passed. A
+second clean full run did not complete because the Docker daemon became
+unresponsive and its YDB Testcontainer disappeared. Therefore this slice does
+not yet have a green full-suite result.
 
 ## P1 — retry and transaction hardening
 
@@ -195,8 +238,7 @@ runtime for the set-based implementation.
   committed an internal batch.
 - Add unit tests for status classification, interrupted backoff, rollback
   failure suppression, connection cleanup, and a failure after commit.
-- Define memory/backpressure limits for buffered merge pages; memory usage must
-  not remain unreported.
+- Apply and verify the P0 memory/backpressure limits for buffered merge pages.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/docs/plans/2026-08-20-ydb-merge-key-contract.md
+++ b/ydb-trino-adapter/docs/plans/2026-08-20-ydb-merge-key-contract.md
@@ -1,0 +1,63 @@
+# YDB MERGE Physical-Key Contract Plan
+
+**Goal:** Reject physical YDB primary-key changes before remote mutation and
+verify that UPDATE/DELETE/INSERT MERGE operations address complete composite
+keys even when the first visible column is not a key.
+
+**Architecture:** Keep the current direct-to-target merge transaction. Resolve
+physical keys once through JDBC metadata, then validate direct UPDATE
+assignments in `YdbClient.update` and row-level UPDATE/MERGE cases in
+`YdbClient.beginMerge`. Do not emulate a key change with delete+insert in this
+slice. The pinned YDB JDBC 2.3.18 driver already rewrites eligible JDBC batches
+to typed set-based YQL; connector-owned batching and resource bounds remain
+separate follow-up work.
+
+**Stack:** Trino 479, YDB JDBC 2.3.18, Java 25, Docker-backed real-YDB tests.
+
+## Constraints
+
+- Work only in `ydb-trino-adapter/` on `codex/ydb-merge-key-contract`, stacked
+  on the catalog-federation branch.
+- Preserve all UPDATE/MERGE capability declarations and inherited tests.
+- Compare assignments with the ordered physical key metadata, never with the
+  first visible column or a test-only logical key.
+- Fail with Trino `NOT_SUPPORTED` before opening the merge transaction or
+  executing direct UPDATE YQL; name every offending key column.
+- Keep target contents unchanged after every rejected statement.
+- Use raw YDB DDL for focused tests so the visible composite key is physical.
+- Do not add another SQL/YQL batch rewriter or claim bounded memory/at-most-once
+  commit semantics in this slice.
+
+## Tasks
+
+1. Add one `YdbClient` physical-key assignment validator and call it from both
+   `update` and `beginMerge`.
+2. Add a real-YDB composite-key MERGE test with a non-key leading column and
+   update/delete/insert branches.
+3. Add direct UPDATE and MERGE physical-key rejection assertions, including
+   error code/message and full unchanged-table checks.
+4. Correct `ROADMAP.md`: eligible merge batches are already set-based through
+   pinned JDBC defaults; the remaining P0 debt is composite-key proof,
+   unbounded memory/request size, and uncertain-commit replay/staging.
+5. Run compile, focused tests, inherited UPDATE/MERGE coverage, the complete
+   adapter suite, diff review, and a clean-worktree check before pushing.
+
+## Validation
+
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -f ydb-trino-adapter/pom.xml -DskipTests compile
+
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn -f ydb-trino-adapter/pom.xml \
+  -Dtest='TestYdbConnectorTest#testMergeUsesCompleteCompositePrimaryKeyWithNonKeyFirstColumn+testPhysicalPrimaryKeyUpdatesAreRejectedWithoutMutation' test
+
+JAVA_HOME=$(/usr/libexec/java_home -v 25) \
+DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+  mvn --batch-mode --update-snapshots -f ydb-trino-adapter/pom.xml clean test
+```
+
+Record only fresh passed/failed/skipped counts. A green result does not close
+the later bounded-memory, staging/finalize, or retry-hardening work.

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -879,6 +879,11 @@ public class YdbClient extends BaseJdbcClient {
         if (primaryKeys.isEmpty()) {
             throw new TrinoException(NOT_SUPPORTED, "The connector cannot perform MERGE on a table without a primary key");
         }
+        rejectPrimaryKeyUpdates(
+                primaryKeys,
+                updateColumnHandles.values().stream()
+                        .flatMap(Collection::stream)
+                        .map(JdbcColumnHandle.class::cast));
 
         SchemaTableName schemaTableName = handle.getRequiredNamedRelation().getSchemaTableName();
         RemoteTableName remoteTableName = handle.getRequiredNamedRelation().getRemoteTableName();
@@ -941,6 +946,16 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public OptionalLong update(ConnectorSession session, JdbcTableHandle handle) {
+        List<JdbcColumnHandle> primaryKeys = getPrimaryKeys(
+                session,
+                handle.getRequiredNamedRelation().getRemoteTableName());
+        if (primaryKeys.isEmpty()) {
+            throw new TrinoException(NOT_SUPPORTED, "YDB DML requires a table primary key");
+        }
+        rejectPrimaryKeyUpdates(
+                primaryKeys,
+                handle.getUpdateAssignments().stream().map(assignment -> assignment.column()));
+
         try (Connection connection = connectionFactory.openConnection(session)) {
             PreparedQuery preparedQuery = queryBuilder.prepareUpdateQuery(
                     this,
@@ -950,7 +965,7 @@ public class YdbClient extends BaseJdbcClient {
                     handle.getConstraint(),
                     getAdditionalPredicate(handle.getConstraintExpressions(), Optional.empty()),
                     handle.getUpdateAssignments());
-            return OptionalLong.of(executeReturningDml(session, connection, handle, preparedQuery));
+            return OptionalLong.of(executeReturningDml(session, connection, preparedQuery, primaryKeys));
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -968,6 +983,14 @@ public class YdbClient extends BaseJdbcClient {
         if (primaryKeys.isEmpty()) {
             throw new TrinoException(NOT_SUPPORTED, "YDB DML requires a table primary key");
         }
+        return executeReturningDml(session, connection, preparedQuery, primaryKeys);
+    }
+
+    private long executeReturningDml(
+            ConnectorSession session,
+            Connection connection,
+            PreparedQuery preparedQuery,
+            List<JdbcColumnHandle> primaryKeys) throws SQLException {
         PreparedQuery returningQuery = preparedQuery.transformQuery(
                 query -> query + " RETURNING " + quoted(primaryKeys.getFirst().getColumnName()));
 
@@ -979,6 +1002,26 @@ public class YdbClient extends BaseJdbcClient {
             }
         }
         return affectedRows;
+    }
+
+    private static void rejectPrimaryKeyUpdates(
+            List<JdbcColumnHandle> primaryKeys,
+            Stream<JdbcColumnHandle> updatedColumns) {
+        Set<String> updatedColumnNames = updatedColumns
+                .map(JdbcColumnHandle::getColumnName)
+                .collect(Collectors.toSet());
+        List<String> updatedPrimaryKeyNames = primaryKeys.stream()
+                .map(JdbcColumnHandle::getColumnName)
+                .filter(updatedColumnNames::contains)
+                .toList();
+        if (!updatedPrimaryKeyNames.isEmpty()) {
+            String columnLabel = updatedPrimaryKeyNames.size() == 1 ? "column" : "columns";
+            throw new TrinoException(
+                    NOT_SUPPORTED,
+                    "Cannot update YDB primary key %s: %s".formatted(
+                            columnLabel,
+                            String.join(", ", updatedPrimaryKeyNames)));
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -211,8 +211,9 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         try {
             assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
                     "('shared', 1, 10, 'old'), " +
+                    "('shared', 1, 20, 'sibling'), " +
                     "('shared', 2, 20, 'remove'), " +
-                    "('keep', 3, 30, 'stable')", 3);
+                    "('keep', 3, 30, 'stable')", 4);
 
             assertUpdate("""
                     MERGE INTO "%s" target
@@ -232,6 +233,7 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                     "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
                     "VALUES " +
                             "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'updated'), " +
+                            "('shared', CAST(1 AS BIGINT), CAST(20 AS BIGINT), 'sibling'), " +
                             "('keep', CAST(3 AS BIGINT), CAST(30 AS BIGINT), 'stable'), " +
                             "('shared', CAST(4 AS BIGINT), CAST(40 AS BIGINT), 'inserted')");
         } finally {

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
 
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -202,6 +203,80 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         }
     }
 
+    @Test
+    public void testMergeUsesCompleteCompositePrimaryKeyWithNonKeyFirstColumn() throws Exception {
+        String table = "merge_composite_key_" + uniqueSuffix();
+
+        createRawCompositePrimaryKeyTable(table);
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
+                    "('shared', 1, 10, 'old'), " +
+                    "('shared', 2, 20, 'remove'), " +
+                    "('keep', 3, 30, 'stable')", 3);
+
+            assertUpdate("""
+                    MERGE INTO "%s" target
+                    USING (VALUES
+                        (BIGINT '1', BIGINT '10', 'updated', 'update'),
+                        (BIGINT '2', BIGINT '20', 'unused', 'delete'),
+                        (BIGINT '4', BIGINT '40', 'inserted', 'insert'))
+                        AS source(account, region, note, operation)
+                    ON target.account = source.account AND target.region = source.region
+                    WHEN MATCHED AND source.operation = 'delete' THEN DELETE
+                    WHEN MATCHED THEN UPDATE SET bucket = 'shared', note = source.note
+                    WHEN NOT MATCHED THEN INSERT (bucket, account, region, note)
+                        VALUES ('shared', source.account, source.region, source.note)
+                    """.formatted(table), 3);
+
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    "VALUES " +
+                            "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'updated'), " +
+                            "('keep', CAST(3 AS BIGINT), CAST(30 AS BIGINT), 'stable'), " +
+                            "('shared', CAST(4 AS BIGINT), CAST(40 AS BIGINT), 'inserted')");
+        } finally {
+            dropRawTable(table);
+        }
+    }
+
+    @Test
+    public void testPhysicalPrimaryKeyUpdatesAreRejectedWithoutMutation() throws Exception {
+        String table = "update_physical_key_" + uniqueSuffix();
+        String unchangedRows = "VALUES " +
+                "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'first'), " +
+                "('shared', CAST(2 AS BIGINT), CAST(20 AS BIGINT), 'second')";
+
+        createRawCompositePrimaryKeyTable(table);
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
+                    "('shared', 1, 10, 'first'), " +
+                    "('shared', 2, 20, 'second')", 2);
+
+            assertThat(query("UPDATE \"" + table + "\" SET account = 11 WHERE account = 1 AND region = 10"))
+                    .failure()
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("Cannot update YDB primary key column: account");
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    unchangedRows);
+
+            assertThat(query("""
+                    MERGE INTO "%s" target
+                    USING (VALUES (BIGINT '1', BIGINT '10')) AS source(account, region)
+                    ON target.account = source.account AND target.region = source.region
+                    WHEN MATCHED THEN UPDATE SET region = target.region + 10, account = target.account + 10
+                    """.formatted(table)))
+                    .failure()
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("Cannot update YDB primary key columns: account, region");
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    unchangedRows);
+        } finally {
+            dropRawTable(table);
+        }
+    }
+
     private static String uniqueSuffix() {
         return UUID.randomUUID().toString().replace("-", "");
     }
@@ -230,6 +305,15 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                 Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE `" + remoteTable + "` " +
                     "(id Int64 NOT NULL, note Utf8, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void createRawCompositePrimaryKeyTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` " +
+                    "(bucket Utf8, account Int64 NOT NULL, region Int64 NOT NULL, note Utf8, " +
+                    "PRIMARY KEY (account, region))");
         }
     }
 

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -212,8 +212,9 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
             assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
                     "('shared', 1, 10, 'old'), " +
                     "('shared', 1, 20, 'sibling'), " +
+                    "('shared', 2, 10, 'cross-sibling'), " +
                     "('shared', 2, 20, 'remove'), " +
-                    "('keep', 3, 30, 'stable')", 4);
+                    "('keep', 3, 30, 'stable')", 5);
 
             assertUpdate("""
                     MERGE INTO "%s" target
@@ -234,6 +235,7 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                     "VALUES " +
                             "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'updated'), " +
                             "('shared', CAST(1 AS BIGINT), CAST(20 AS BIGINT), 'sibling'), " +
+                            "('shared', CAST(2 AS BIGINT), CAST(10 AS BIGINT), 'cross-sibling'), " +
                             "('keep', CAST(3 AS BIGINT), CAST(30 AS BIGINT), 'stable'), " +
                             "('shared', CAST(4 AS BIGINT), CAST(40 AS BIGINT), 'inserted')");
         } finally {


### PR DESCRIPTION
## Summary

- reject direct UPDATE and MERGE changes to physical YDB primary-key columns with `NOT_SUPPORTED` before remote mutation;
- resolve composite primary keys from JDBC metadata in `KEY_SEQ` order instead of assuming the first visible column is a key;
- verify complete composite-key addressing across MERGE update/delete/insert branches, including sibling rows with colliding individual key components;
- document the pinned JDBC batch contract and the remaining memory, retry, and staging limitations.

## Verification

GitHub Actions run [32380080735](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32380080735) on head `f798b6a`:

- 338 tests total;
- 0 failures, 0 errors, 84 skipped;
- `TestYdbConnectorTest`: 288 total, 80 skipped;
- `TestYdbConnectorSmokeTest`: 36 total, 4 skipped;
- federation: 6/6 passed.

## Remaining limitations

- physical primary-key changes are rejected rather than emulated as atomic delete+insert;
- MERGE page/request memory is not yet bounded;
- an uncertain commit outcome is not replay-safe without staging/finalize or an operation id.

Stacked on #243; keep draft until its base PRs land.
