### PR TITLE
Harden YDB Trino connector for production readiness

### DIFF
--- a/ydb-trino-adapter/README.md
+++ b/ydb-trino-adapter/README.md
@@ -59,6 +59,41 @@ is the working local single-database example mounted by
 production, create `ydb_prod.properties` and a separate analytics catalog file
 using the secret references above.
 
+## Extended temporal types
+
+The connector enables the YDB JDBC 2.3.18 option
+`forceSignedDatetimes=true` for every connection. This makes the driver's wide
+temporal bindings available by default. Do not override this option to `false`
+in `connection-url`; URL options take precedence over the connection properties
+supplied by the connector.
+
+New Trino `date` columns are created as YDB `Date32`, and new Trino
+`timestamp(6)` columns are created as `Timestamp64`. Existing YDB temporal
+columns remain readable: `Date` and `Date32` map to Trino `date`, `Datetime` and
+`Datetime64` map to `timestamp(0)`, and `Timestamp` and `Timestamp64` map to
+`timestamp(6)`. The signed types preserve values before 1970; `Timestamp64`
+preserves microseconds. Predicates outside the physical YDB type's range remain
+in Trino instead of being bound to JDBC.
+
+The option is defined by the pinned driver in
+[`YdbOperationProperties`](https://github.com/ydb-platform/ydb-jdbc-driver/blob/v2.3.18/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbOperationProperties.java#L60-L62).
+The YDB type name is `Timestamp64` (not `Timestampt64`); see the
+[primitive type reference](https://ydb.tech/docs/en/yql/reference/types/primitive).
+
+Atomic MERGE buffers input so a safe pre-commit retry can replay the complete
+operation while preserving the global delete/update/insert phase order. Each
+MERGE sink is limited to 64 MB of retained input by default. Operators may tune
+the finite limit per catalog:
+
+```properties
+merge.max-buffer-size=128MB
+```
+
+If the limit is exceeded, the connector fails the MERGE before opening its YDB
+connection or mutating the target. Trino 479's `ConnectorMergeSink` input method
+does not expose asynchronous backpressure, so this is a fail-fast bound rather
+than spill-to-disk.
+
 A table name is the complete YDB path relative to that catalog's configured
 database root. Select the only schema, then quote a nested path as one Trino
 identifier:
@@ -68,9 +103,12 @@ USE ydb_prod.default;
 SELECT * FROM "sales/eu/orders";
 ```
 
-Each YDB path component is limited to 255 characters. The connector does not
-apply that limit to the complete relative path, so a deeper path remains valid
-when every component is valid.
+Each YDB path component is limited to 255 characters, and a relative object
+path may contain at most 32 components. The connector does not apply the
+component-length limit to the complete relative path, so a deeper path remains
+valid within that hierarchy limit when every component is valid.
+See YDB's [database object naming rules](https://ydb.tech/docs/en/concepts/datamodel/cluster-namespace)
+and [database limits](https://ydb.tech/docs/en/concepts/limits-ydb).
 
 Catalogs may be joined, but the join is executed by Trino rather than pushed
 down to YDB:
@@ -82,9 +120,9 @@ JOIN ydb_analytics.default.customer_segment a ON p.customer_id = a.customer_id;
 ```
 
 Trino 479 permits one autocommit statement to read from several catalogs and
-write to one target catalog. This YDB federation topology has not yet been
-integration-tested and does not provide a cross-catalog snapshot or distributed
-commit.
+write to one target catalog. The integration fixture covers this topology with
+two independent YDB instances. It does not provide a cross-catalog snapshot or
+distributed commit.
 
 Cross-catalog reads may also run in an explicit transaction. YDB is a
 single-statement-write connector: when YDB is the first or only write target,

--- a/ydb-trino-adapter/README.md
+++ b/ydb-trino-adapter/README.md
@@ -25,3 +25,83 @@ docker-compose up -d
 
 docker exec -it ydb-trino trino
 ```
+
+## YDB catalogs and table paths
+
+Configure one static Trino catalog for each YDB database. A catalog is a
+connection and security boundary; the connector exposes only the virtual
+`default` schema and does not discover YDB databases.
+
+For example, deploy these two files under Trino's `etc/catalog/` directory.
+The environment values must be injected from the deployment secret manager;
+they are placeholders, not credentials to copy into source control.
+
+`ydb_prod.properties`:
+
+```properties
+connector.name=ydb
+connection-url=${ENV:YDB_PROD_JDBC_URL}
+```
+
+`ydb_analytics.properties`:
+
+```properties
+connector.name=ydb
+connection-url=${ENV:YDB_ANALYTICS_JDBC_URL}
+```
+
+For example, `YDB_PROD_JDBC_URL` is a secret reference resolving to a complete
+JDBC URL for the production database, including any authentication material.
+Never store a real token or credential in a catalog file. The bundled
+[`examples/trino/etc/catalog/ydb.properties`](examples/trino/etc/catalog/ydb.properties)
+is the working local single-database example mounted by
+`examples/docker-compose.yml`; it intentionally points at `ydb-local`. For
+production, create `ydb_prod.properties` and a separate analytics catalog file
+using the secret references above.
+
+A table name is the complete YDB path relative to that catalog's configured
+database root. Select the only schema, then quote a nested path as one Trino
+identifier:
+
+```sql
+USE ydb_prod.default;
+SELECT * FROM "sales/eu/orders";
+```
+
+Each YDB path component is limited to 255 characters. The connector does not
+apply that limit to the complete relative path, so a deeper path remains valid
+when every component is valid.
+
+Catalogs may be joined, but the join is executed by Trino rather than pushed
+down to YDB:
+
+```sql
+SELECT p.order_id, a.segment
+FROM ydb_prod.default."sales/eu/orders" p
+JOIN ydb_analytics.default.customer_segment a ON p.customer_id = a.customer_id;
+```
+
+Trino 479 permits one autocommit statement to read from several catalogs and
+write to one target catalog. This YDB federation topology has not yet been
+integration-tested and does not provide a cross-catalog snapshot or distributed
+commit.
+
+Cross-catalog reads may also run in an explicit transaction. YDB is a
+single-statement-write connector: when YDB is the first or only write target,
+Trino rejects the write before connector mutation with `Catalog only supports
+writes using autocommit: <catalog>`. A read-only transaction or an earlier write
+to another catalog can instead produce the corresponding read-only or
+multi-catalog-write error.
+
+Trino 479 can alternatively enable the experimental deployment feature
+`catalog.management=dynamic` and create the same catalog instances with
+`CREATE CATALOG`. This is not YDB database discovery. Do not place secrets in a
+`CREATE CATALOG` statement: Trino logs the complete statement and displays it
+in the Web UI. Use static catalog files and secret references for production
+credentials.
+
+```sql
+CREATE CATALOG ydb_analytics
+USING ydb
+WITH ("connection-url" = 'jdbc:ydb:grpcs://<endpoint>/<database>?token=<secret>');
+```

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -198,15 +198,20 @@ comment has not yet been verified.
    remote mutation with `NOT_SUPPORTED`. Atomic delete+insert remains a
    possible future extension. See the
    [YQL UPDATE contract](https://ydb.tech/docs/en/yql/reference/syntax/update).
-4. Define and test page/request memory limits. The connector retains all input
-   pages until `finish()`, then creates operation-specific pages while the
-   driver retains the corresponding row structs and list parameter. No current
-   bounded-memory or maximum-request-size claim is made.
-5. In-memory lifecycle tests inject a retryable batch failure before commit and
-   verify replay on a fresh connection, then inject a retryable commit failure
-   and verify one connection, one commit invocation, no replay, rollback/close
-   cleanup, and preservation of the original exception. Extend rollback-failure
-   suppression coverage separately.
+4. MERGE now reuses Trino's validated `write_batch_size` session property and
+   executes each DELETE, UPDATE-case, and INSERT JDBC batch in row-bounded
+   chunks without intermediate commits. It scans the original pages by phase
+   instead of retaining operation-specific pages and position arrays, and
+   releases the original pages after the terminal outcome. The complete input
+   is still buffered through internal retries, and the row limit is not a byte
+   or serialized-request limit; no bounded-memory claim is made yet.
+5. In-memory lifecycle tests inject a retryable failure after one sub-batch and
+   verify complete replay on a fresh connection, then inject a retryable commit
+   failure and verify no replay, rollback/close cleanup, and preservation of
+   the original exception. Mixed-operation coverage verifies phase ordering,
+   composite row-id keys, original update-channel mapping, row-bounded chunks,
+   one final commit, and rejection of an unknown update case before remote
+   mutation. Extend rollback-failure suppression separately.
 
 **Exit criterion:** retain the green inherited `testMerge*` suite, cover the
 physical composite-key and rejection contracts, and demonstrate the chosen
@@ -224,6 +229,15 @@ port allocator 3/0. That run verified the physical-key rejection contract and
 the initial cross-sibling fixture. Final review added the complementary
 cross-sibling needed to catch either operation using either individual key;
 the required GitHub Actions check on PR #244 gates that final test-only change.
+
+### MERGE sub-batch slice validation (2026-08-20)
+
+A focused JDK 25 run of `TestYdbMergeSink` reported 5 tests, 0 failures,
+0 errors, and 0 skipped without initializing Docker. It covers the
+pre-commit fresh-transaction retry, ambiguous-commit no-replay boundary,
+`write_batch_size` chunking without intermediate commits, mixed-operation
+phase/key/channel mapping, and invalid-update-case preflight. This focused run
+does not replace the inherited real-YDB MERGE suite or the full module suite.
 
 ## P1 — retry and transaction hardening
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -33,6 +33,37 @@ on 2026-08-20 at `619b33d` reported 336 tests: 0 failures, 0 errors, and
 the non-ephemeral port allocator 3/0/0/0, Connector 286/80, Smoke 36/4, and
 TablePath 5/0.
 
+## Extended temporal contract
+
+The pinned YDB JDBC driver is 2.3.18. Its extended temporal mode is controlled
+by `forceSignedDatetimes`, declared by
+[`YdbOperationProperties.FORCE_NEW_DATETYPES`](https://github.com/ydb-platform/ydb-jdbc-driver/blob/v2.3.18/jdbc/src/main/java/tech/ydb/jdbc/settings/YdbOperationProperties.java#L60-L62),
+and defaults to `false` in the driver. The connector now supplies
+`forceSignedDatetimes=true` by default. An explicit value in the JDBC URL still
+wins over supplied connection properties and must not be set to `false` for
+this connector contract.
+
+- new Trino `date` writes and DDL use YDB `Date32`;
+- new Trino `timestamp(6)` writes and DDL use YDB `Timestamp64`;
+- existing `Date`/`Date32`, `Datetime`/`Datetime64`, and
+  `Timestamp`/`Timestamp64` columns map respectively to Trino `date`,
+  `timestamp(0)`, and `timestamp(6)`;
+- `Timestamp64` is read and written through JDBC `Instant` at UTC, avoiding the
+  driver's JVM-default-zone `LocalDateTime` conversion and preserving
+  microseconds;
+- predicate pushdown is limited to the range of the physical YDB temporal type,
+  so an out-of-range Trino constant is evaluated by Trino instead of being
+  bound to JDBC.
+
+The type name is `Timestamp64`, not `Timestampt64`. The contract and ranges
+come from the [YDB primitive type reference](https://ydb.tech/docs/en/yql/reference/types/primitive).
+The driver flag and signed mappings were introduced in
+[`ydb-jdbc-driver` PR #116](https://github.com/ydb-platform/ydb-jdbc-driver/pull/116).
+Focused unit coverage has 7 tests, and two real-YDB integration tests cover
+pre-1970 values, nulls, second-versus-microsecond precision, legacy and wide
+types in the same table, predicate binding, and the physical types created by
+Trino.
+
 ## Approved namespace and catalog contract
 
 The public namespace model was agreed on 2026-08-19:
@@ -71,10 +102,13 @@ SQL clients rather than as a directory tree.
 The connector must parse paths into components before producing YQL. It rejects
 absolute paths, empty components, leading/trailing or repeated `/`, `.` and
 `..`, dot-prefixed/system components, invalid YDB component names, and
-components longer than the 255-character YDB component limit. It does not impose
-an artificial 255-character limit on the complete relative path. The validated
-full path is quoted as one YQL identifier through the connector quoting helper.
-It is not assembled by call-site string concatenation.
+components longer than the 255-character YDB component limit. It also rejects
+paths deeper than YDB's 32-component database limit. It does not impose an
+artificial 255-character limit on the complete relative path. The validated full
+path is quoted as one YQL identifier through the connector quoting helper. It is
+not assembled by call-site string concatenation. These limits follow YDB's
+[database object naming rules](https://ydb.tech/docs/en/concepts/datamodel/cluster-namespace)
+and [database limits](https://ydb.tech/docs/en/concepts/limits-ydb).
 
 Trino 479 normalizes SQL identifiers to lowercase, including delimited
 identifiers. YDB paths are case-sensitive. A lowercase Trino name may resolve to
@@ -178,8 +212,10 @@ The rewrite requires the simple SQL shape recognized by the driver's
 `YqlBatcher`, complete primary-key equality for UPDATE/DELETE,
 `disablePrepareDataQuery=false`, `disableAutoPreparedBatches=false`, and no
 query modifier that changes the recognized shape. In particular, the default
-blank `query.comment-format` preserves batching; a configured remote-query
-comment has not yet been verified.
+blank `query.comment-format` preserves batching. A pinned-driver parser test
+also verifies that Trino's trailing block-comment shape preserves automatic
+batch recognition for the connector's DELETE, UPDATE, and INSERT SQL. This does
+not instrument or count real remote requests.
 
 1. The focused MERGE contract test now uses a composite metadata primary key,
    a non-key leading visible column, and two cross-sibling rows covering both
@@ -203,15 +239,22 @@ comment has not yet been verified.
    chunks without intermediate commits. It scans the original pages by phase
    instead of retaining operation-specific pages and position arrays, and
    releases the original pages after the terminal outcome. The complete input
-   is still buffered through internal retries, and the row limit is not a byte
-   or serialized-request limit; no bounded-memory claim is made yet.
+   remains buffered through internal retries, but retained input is now bounded
+   to 64 MB per sink by default through the configurable
+   `merge.max-buffer-size`. Exceeding the limit fails before a connection is
+   opened or YDB is mutated. `ConnectorMergeSink.storeMergedRows` returns
+   `void`, so this is a fail-fast bound rather than asynchronous backpressure or
+   spill-to-disk. The JDBC row limit is still not a byte or serialized-request
+   limit.
 5. In-memory lifecycle tests inject a retryable failure after one sub-batch and
    verify complete replay on a fresh connection, then inject a retryable commit
    failure and verify no replay, rollback/close cleanup, and preservation of
    the original exception. Mixed-operation coverage verifies phase ordering,
    composite row-id keys, original update-channel mapping, row-bounded chunks,
-   one final commit, and rejection of an unknown update case before remote
-   mutation. Extend rollback-failure suppression separately.
+   one final commit, rejection of an unknown update case before remote mutation,
+   the retained-memory boundary before remote mutation, successful-commit close
+   failure handling, and suppression of rollback/close failures without
+   replacing the original SQL failure.
 
 **Exit criterion:** retain the green inherited `testMerge*` suite, cover the
 physical composite-key and rejection contracts, and demonstrate the chosen
@@ -271,12 +314,15 @@ does not replace the inherited real-YDB MERGE suite or the full module suite.
   source columns' physical JDBC type names/nullability and a collision-safe
   hidden `BigSerial` primary key. Trino still performs one final
   `INSERT ... SELECT` into the target and drops the staging table. A real-YDB
-  atomicity test is present but has not run because local Colima is stopped;
-  no transactional INSERT support claim is made yet.
+  atomicity test verifies that a duplicate-key failure in a staged insert does
+  not partially mutate the target and that a following valid staged insert
+  succeeds.
 - Focused unit tests now cover status classification, interrupted backoff while
   preserving the final SQL failure as the cause, pre-commit connection cleanup,
-  and failure after commit. Rollback-failure suppression remains to be added.
-- Apply and verify the P0 memory/backpressure limits for buffered merge pages.
+  failure after commit, and suppression of rollback/close failures without
+  replacing the original SQL failure.
+- Exercise and tune the MERGE memory limit with a production-scale workload;
+  the unit boundary is covered, but spill-to-disk is not implemented.
 
 ### Retry-classification slice validation (2026-08-20)
 
@@ -304,8 +350,9 @@ reported 1 test, 0 failures, 0 errors, and 0 skipped without initializing
 Docker; it verifies full-path quoting, collision-safe staging-key generation,
 physical remote type preservation, nullability, and requested column order.
 `testTransactionalInsertStagingDoesNotPartiallyMutateTarget` compiles and is the
-pending real-YDB gate: with batch size one, a later duplicate-key failure must
-not leave an earlier row in the target, followed by a successful staged insert.
+real-YDB gate: with batch size one, a later duplicate-key failure does not leave
+an earlier row in the target, followed by a successful staged insert. The gate
+passed as part of the complete local suite on 2026-08-24.
 
 ### Clean integration snapshot validation (2026-08-21)
 
@@ -315,7 +362,26 @@ compile succeeded. One focused run of `TestYdbTablePath`,
 `TestNonEphemeralPortsGenerator`, `TestYdbMergeSink`, `TestYdbRetryUtils`, and
 `TestYdbInsertStaging` reported 17 tests, 0 failures, 0 errors, and 0 skipped.
 These tests did not initialize Docker. The real-YDB transactional INSERT gate
-and complete module suite remain pending.
+and complete module suite were still pending at that snapshot.
+
+### Local readiness audit validation (2026-08-21)
+
+A fresh JDK 25 no-Docker run after the readiness fixes reported 24 tests,
+0 failures, 0 errors, and 0 skipped. It includes 10 MERGE lifecycle/resource
+tests, six path tests, three port-allocation tests, two retry-classification
+tests, and one test each for INSERT staging, date predicate control, and pinned
+JDBC auto-batch parsing. The real-YDB focused gates and complete module suite
+were still pending at that audit snapshot.
+
+### Complete local validation (2026-08-24)
+
+A JDK 25 `clean test` run with Testcontainers and Colima reported 364 tests,
+0 failures, 0 errors, and 84 skipped, leaving 280 passed. It included Connector
+291/80, Smoke 36/4, Federation 6/0, ColumnMappings 8/0, MergeSink 10/0,
+TablePath 6/0, NonEphemeralPorts 3/0, RetryUtils 2/0, and one test each for
+INSERT staging and pinned JDBC batching. This is a local compatibility result
+for the unpinned YDB test-helper image that resolved on that run; it is not an
+image-version compatibility baseline.
 
 ## P2 — remove remaining test debt
 
@@ -326,16 +392,33 @@ unsupported behavior, record:
 2. an authoritative documentation link or tracked upstream issue;
 3. a focused negative test that proves the connector fails clearly.
 
-The existing negative-date, CHAR, cast-pushdown, and default-column overrides
-need this treatment. YDB `Date` starts at the Unix epoch; see
-[primitive types](https://ydb.tech/docs/en/yql/reference/types/primitive).
+The former false negative-date declaration has been removed: Trino-created
+columns use `Date32`, while legacy YDB `Date` predicates outside 1970-01-01
+through 2105-12-31 remain in Trino. CHAR is rejected with the focused inherited
+contract (`Unsupported column type: char(3)`) because YDB has no fixed-width
+string primitive and mapping it to `Text` would lose Trino padding semantics.
+A YDB-native fixture replaces the former empty default-column INSERT override.
+
+### Capability audit (Trino 479)
+
+| Behavior group | Declaration and verified reason |
+| --- | --- |
+| schema DDL and cross-schema rename | false: `default` is a virtual, fixed root schema; focused namespace and federation tests cover the boundary |
+| TRUNCATE | false by the target connector contract; the inherited unsupported branch verifies `NOT_SUPPORTED` |
+| ARRAY, MAP, ROW | false: YDB container types cannot be table column types; inherited unsupported data-mapping branches cover writes ([YDB containers](https://ydb.tech/docs/en/yql/reference/types/containers)) |
+| column/table comments and add-column comments | false: the YDB table DDL used by the connector has no Trino comment contract; inherited negative branches verify clear rejection |
+| add-column position, rename column, set column type | false: current YDB column DDL documents add, option changes, and drop, but no `FIRST`/`AFTER`, rename-column, or type-change form ([changing columns](https://ydb.tech/docs/en/yql/reference/syntax/alter_table/columns)) |
+| views and materialized views | false: although current YDB has `CREATE VIEW`, it requires YDB-specific definition/security handling that the connector does not model; no view SPI implementation is present ([CREATE VIEW](https://ydb.tech/docs/en/yql/reference/syntax/create-view)) |
+| default column values | false: Trino 479 exposes one catalog capability across CREATE, ADD, INSERT, MERGE, SET, and DROP. A seven-test real-YDB audit produced 1 pass, 3 failures, and 3 errors: YDB rejects `DEFAULT NULL`, MERGE staging does not preserve omitted defaults, and Base JDBC implements neither SET nor DROP. The inherited `testCreateTableWithDefaultColumn` negative branch and the positive YDB-native insert fixture define the current boundary. YDB itself supports literal defaults on row tables ([CREATE TABLE](https://ydb.tech/docs/en/yql/reference/syntax/create_table)) |
+| add NOT NULL column | false: real YDB rejects adding a non-null column without a default even to an empty table, while the inherited Trino contract requires that statement; the connector rejects it before remote mutation |
 
 ## Later capability work
 
 - List/Dict/Struct mappings for Trino ARRAY/MAP/ROW;
 - views, comments, rename column, and type changes after checking current YQL
   semantics;
-- transactional INSERT/staging instead of direct non-transactional writes.
+- preserve omitted defaults through INSERT/MERGE staging before advertising
+  Trino's coarse `DEFAULT_COLUMN_VALUE` capability.
 
 ## Validation ladder
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -222,13 +222,12 @@ retries after uncertain commit outcomes.
 ### Merge-key slice validation (2026-08-20)
 
 GitHub Actions run
-[`32378003537`](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32378003537)
-at `33bfb8f` reported 338 tests, 0 failures, 0 errors, and 84 skipped. It
+[`32380080735`](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32380080735)
+at `f798b6a` reported 338 tests, 0 failures, 0 errors, and 84 skipped. It
 included Connector 288/80, Smoke 36/4, Federation 6/0, TablePath 5/0, and the
-port allocator 3/0. That run verified the physical-key rejection contract and
-the initial cross-sibling fixture. Final review added the complementary
-cross-sibling needed to catch either operation using either individual key;
-the required GitHub Actions check on PR #244 gates that final test-only change.
+port allocator 3/0. This final run includes both cross-sibling composite-key
+cases and verifies that neither operation can accidentally use only one key
+component.
 
 ### MERGE sub-batch slice validation (2026-08-20)
 
@@ -307,6 +306,16 @@ physical remote type preservation, nullability, and requested column order.
 `testTransactionalInsertStagingDoesNotPartiallyMutateTarget` compiles and is the
 pending real-YDB gate: with batch size one, a later duplicate-key failure must
 not leave an earlier row in the target, followed by a successful staged insert.
+
+### Clean integration snapshot validation (2026-08-21)
+
+The review branches were reconstructed from current `main` as one local
+integration branch without the three internal `docs/plans` artifacts. JDK 25
+compile succeeded. One focused run of `TestYdbTablePath`,
+`TestNonEphemeralPortsGenerator`, `TestYdbMergeSink`, `TestYdbRetryUtils`, and
+`TestYdbInsertStaging` reported 17 tests, 0 failures, 0 errors, and 0 skipped.
+These tests did not initialize Docker. The real-YDB transactional INSERT gate
+and complete module suite remain pending.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -266,8 +266,14 @@ does not replace the inherited real-YDB MERGE suite or the full module suite.
   every full JDBC batch. The integration fixture explicitly enables
   `insert.non-transactional-insert.enabled=true`, so a failed test INSERT may
   leave already committed target rows; query/task retries remain disabled.
-  Production-default staging and finalization still require real-YDB
-  verification before making a transactional INSERT claim.
+  Trino's default staging path previously generated `CREATE TABLE AS SELECT`,
+  which cannot create a row-oriented YDB table and omitted YDB's mandatory
+  primary key. The connector now creates a regular staging table with the
+  source columns' physical JDBC type names/nullability and a collision-safe
+  hidden `BigSerial` primary key. Trino still performs one final
+  `INSERT ... SELECT` into the target and drops the staging table. A real-YDB
+  atomicity test is present but has not run because local Colima is stopped;
+  no transactional INSERT support claim is made yet.
 - Focused unit tests now cover status classification, interrupted backoff while
   preserving the final SQL failure as the cause, pre-commit connection cleanup,
   and failure after commit. Rollback-failure suppression remains to be added.
@@ -288,6 +294,19 @@ errors, and 0 skipped without initializing Docker. The added case interrupts a
 retry backoff after a retryable batch failure and verifies the interrupt flag,
 the original SQL exception as the `TrinoException` cause, the interrupted
 sleep as suppressed evidence, and rollback/close cleanup.
+
+### Transactional INSERT staging slice (2026-08-20)
+
+Official YQL documents that a primary key is mandatory for YDB tables and that
+`CREATE TABLE AS SELECT` currently supports only column-oriented tables. Source
+inspection of Trino 479 confirmed that its generic staging path emits a CTAS
+without a primary key. A focused JDK 25 unit run of `TestYdbInsertStaging`
+reported 1 test, 0 failures, 0 errors, and 0 skipped without initializing
+Docker; it verifies full-path quoting, collision-safe staging-key generation,
+physical remote type preservation, nullability, and requested column order.
+`testTransactionalInsertStagingDoesNotPartiallyMutateTarget` compiles and is the
+pending real-YDB gate: with batch size one, a later duplicate-key failure must
+not leave an earlier row in the target, followed by a successful staged insert.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -190,8 +190,10 @@ comment has not yet been verified.
    connection, sets `autoCommit=false`, executes all operation groups, and
    commits once; write parallelism is limited to one and Trino query/task retry
    modes are rejected. Each connector retry opens fresh transactional state.
-   Failure-after-commit behavior is not yet proven, so no at-most-once replay
-   claim is made without an operation-id or staging/finalize design.
+   Once `Connection.commit()` has been invoked, the connector never replays the
+   attempt: a commit exception is reported as an unknown outcome after
+   best-effort rollback and close. Retrying an unknown outcome and returning a
+   definite result still requires an operation-id or staging/finalize design.
 3. Direct UPDATE and MERGE now reject physical primary-key changes before
    remote mutation with `NOT_SUPPORTED`. Atomic delete+insert remains a
    possible future extension. See the
@@ -200,8 +202,11 @@ comment has not yet been verified.
    pages until `finish()`, then creates operation-specific pages while the
    driver retains the corresponding row structs and list parameter. No current
    bounded-memory or maximum-request-size claim is made.
-5. Extend rollback/close and fresh-state retry tests, including an uncertain
-   commit outcome that must not replay an already committed change.
+5. In-memory lifecycle tests inject a retryable batch failure before commit and
+   verify replay on a fresh connection, then inject a retryable commit failure
+   and verify one connection, one commit invocation, no replay, rollback/close
+   cleanup, and preservation of the original exception. Extend rollback-failure
+   suppression coverage separately.
 
 **Exit criterion:** retain the green inherited `testMerge*` suite, cover the
 physical composite-key and rejection contracts, and demonstrate the chosen

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -26,10 +26,12 @@ override and completes within the CI budget. An isolated local Colima run
 previously exceeded 11 minutes, so MERGE scalability remains a production
 concern rather than a CI failure.
 
-Fresh local JDK 25 namespace validation (2026-08-20) reported 327 discovered
-tests: 0 failures, 0 errors, and 84 skipped, leaving 243 executed tests passed.
-It included 5 `TestYdbTablePath` tests, 286 connector tests (80 skipped), and
-36 smoke tests (4 skipped); no other test classes ran.
+GitHub Actions run
+[`32377210642`](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32377210642)
+on 2026-08-20 at `619b33d` reported 336 tests: 0 failures, 0 errors, and
+84 skipped, leaving 252 executed tests passed. It included Federation 6/0/0/0,
+the non-ephemeral port allocator 3/0/0/0, Connector 286/80, Smoke 36/4, and
+TablePath 5/0.
 
 ## Approved namespace and catalog contract
 
@@ -79,7 +81,7 @@ identifiers. YDB paths are case-sensitive. A lowercase Trino name may resolve to
 one unique case-insensitive remote path; case-only collisions must fail with an
 explicit ambiguous-name error rather than selecting an arbitrary object.
 
-### Catalog provisioning and federation
+### Catalog provisioning (approved operator guidance)
 
 Static catalog property files are the production default. For example,
 `ydb_prod.properties` and `ydb_analytics.properties` contain separate YDB JDBC
@@ -90,12 +92,18 @@ YDB database discovery by the connector. Sensitive catalog properties must not
 be placed directly in SQL because the complete statement is logged and visible
 in the Trino Web UI.
 
+This is the approved deployment and operator contract. The verified federation
+slice below did not load production catalog property files or execute SQL
+`CREATE CATALOG`.
+
+### Catalog federation
+
 Federated reads qualify each source by catalog. Cross-catalog joins run in
 Trino; join pushdown requires both tables to belong to the same catalog.
 Trino 479 permits one autocommit statement to read from several catalogs and
 write to one target catalog when the target operation is supported. This
-read-many/write-one YDB topology remains unverified and provides neither a
-cross-catalog snapshot nor a distributed commit.
+read-many/write-one YDB topology provides neither a cross-catalog snapshot nor
+a distributed commit.
 
 Cross-catalog reads may run in an explicit transaction. YDB is a
 single-statement-write connector: when YDB is the first or only write target,
@@ -121,13 +129,36 @@ This slice implements the following items:
    Comment writes remain unsupported, and bulk column metadata remains opt-in.
 
 This slice does not enable schema DDL capabilities or change capability flags.
-Catalog provisioning and cross-catalog federation remain a separate, unverified
-integration slice.
 
 The real-YDB `testNestedTablePathLongerThanSingleComponentLimit` passed in the
 final full suite. It covers a complete relative path longer than 255 characters
 whose components are each at most 255 characters, including listing, selection,
 rename, and cleanup.
+
+### Verified catalog federation (2026-08-20)
+
+The JDK 25 GitHub Actions run at `619b33d` verified the federation slice with
+six tests: five new public scenarios and the inherited naming convention. The
+fixture uses two independent Docker YDB instances, both with database `/local`,
+separate endpoints, and Trino catalogs `ydb` and `ydb_analytics`. It allocates
+fixed container ports outside the standard Linux and macOS ephemeral ranges,
+checks wildcard availability, and retries the complete container start at most
+three times on a Docker host-port collision. The YDB test-helper gRPC proxy is
+not used because its unshaded generated proto stubs are binary-incompatible
+with the same proto class names embedded in `ydb-jdbc-driver-shaded`.
+
+- catalog discovery, `default`/`USE` analysis, and explicit `Session` handling
+  for unqualified access;
+- same-name table isolation, a cross-catalog JOIN evaluated in Trino, and
+  explicit cross-catalog reads;
+- one autocommit statement that reads from both catalogs and writes to one;
+- rejection of the first and only YDB write in an explicit cross-catalog
+  transaction before connector mutation, with the exact error `Catalog only
+  supports writes using autocommit: ydb_analytics` and an empty target table.
+
+This verifies the stated connector behavior only. It does not provide a shared
+snapshot or distributed commit, and it makes no production configuration or
+capability declaration changes.
 
 ## P0 — harden MERGE scalability and atomicity
 
@@ -188,8 +219,6 @@ need this treatment. YDB `Date` starts at the Unix epoch; see
 
 ## Later capability work
 
-- catalog provisioning and YDB-to-YDB federation coverage for the approved
-  single-`default`-schema namespace model;
 - List/Dict/Struct mappings for Trino ARRAY/MAP/ROW;
 - views, comments, rename column, and type changes after checking current YQL
   semantics;

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -262,10 +262,15 @@ does not replace the inherited real-YDB MERGE suite or the full module suite.
   override it. This trades connection reuse for correctness and may increase
   connection latency/load. Re-evaluate the default after upgrading to a driver
   with a verified cache-lifecycle fix.
-- Do not replay buffered INSERT pages after `JdbcPageSink` may already have
-  committed an internal batch.
-- Add unit tests for status classification, interrupted backoff, rollback
-  failure suppression, connection cleanup, and a failure after commit.
+- The adapter adds no retry around Trino 479 `JdbcPageSink`. That sink commits
+  every full JDBC batch. The integration fixture explicitly enables
+  `insert.non-transactional-insert.enabled=true`, so a failed test INSERT may
+  leave already committed target rows; query/task retries remain disabled.
+  Production-default staging and finalization still require real-YDB
+  verification before making a transactional INSERT claim.
+- Focused unit tests now cover status classification, interrupted backoff while
+  preserving the final SQL failure as the cause, pre-commit connection cleanup,
+  and failure after commit. Rollback-failure suppression remains to be added.
 - Apply and verify the P0 memory/backpressure limits for buffered merge pages.
 
 ### Retry-classification slice validation (2026-08-20)
@@ -275,6 +280,14 @@ tests, 0 failures, 0 errors, and 0 skipped without initializing Docker. The
 slice verifies the complete pinned-SDK unconditional status set, nested-cause
 classification, and the existing fresh-connection MERGE lifecycle. It does not
 replace the real-YDB or full module suite.
+
+### Interrupted MERGE retry validation (2026-08-20)
+
+A focused JDK 25 run of `TestYdbMergeSink` reported 6 tests, 0 failures, 0
+errors, and 0 skipped without initializing Docker. The added case interrupts a
+retry backoff after a retryable batch failure and verifies the interrupt flag,
+the original SQL exception as the `TrinoException` cause, the interrupted
+sleep as suppressed evidence, and rollback/close cleanup.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -160,26 +160,65 @@ This verifies the stated connector behavior only. It does not provide a shared
 snapshot or distributed commit, and it makes no production configuration or
 capability declaration changes.
 
-## P0 — harden MERGE scalability and atomicity
+## P0 — validate the JDBC batch/key contract and bound MERGE resources
 
-1. Replace row-by-row prepared-statement execution in `YdbMergeSink` with a
-   set-based YQL path. Candidate primitives are
-   [`UPDATE ... ON`](https://ydb.tech/docs/en/yql/reference/syntax/update) and
-   [`AS_TABLE`](https://ydb.tech/docs/en/yql/reference/syntax/select/from_as_table),
-   using bounded batches of typed list-of-struct parameters.
-2. Preserve one logical MERGE transaction. Until a staging/finalize design is
-   implemented, keep one writer task and reject Trino query/task retries for a
-   direct-to-target merge.
-3. YQL `UPDATE` cannot change a primary-key value. Implement physical-key
-   changes as atomic delete+insert row changes, or reject that statement with a
-   documented `NOT_SUPPORTED` error. See the
+`YdbMergeSink` already calls JDBC `addBatch()` for DELETE, UPDATE, and INSERT.
+Source inspection of the pinned YDB JDBC 2.3.18 driver shows that, with its
+default prepare/auto-batch settings, each eligible non-empty `executeBatch()`
+is represented as one typed `List<Struct>` parameter and one set-based YQL
+request. The generated forms use
+[`UPDATE ... ON`](https://ydb.tech/docs/en/yql/reference/syntax/update),
+`DELETE ... ON`, or `INSERT ... SELECT` over
+[`AS_TABLE($batch)`](https://ydb.tech/docs/en/yql/reference/syntax/select/from_as_table).
+This is driver-owned batching; the connector must not duplicate that rewrite.
+This request cardinality is source-derived; the current connector tests do not
+instrument or count remote requests.
+
+The rewrite requires the simple SQL shape recognized by the driver's
+`YqlBatcher`, complete primary-key equality for UPDATE/DELETE,
+`disablePrepareDataQuery=false`, `disableAutoPreparedBatches=false`, and no
+query modifier that changes the recognized shape. In particular, the default
+blank `query.comment-format` preserves batching; a configured remote-query
+comment has not yet been verified.
+
+1. The focused MERGE contract test now uses a composite metadata primary key,
+   a non-key leading visible column, and two cross-sibling rows covering both
+   individual key components of the UPDATE and DELETE targets. It verifies
+   that both operations address the complete physical key while
+   update/delete/insert branches coexist.
+2. Preserve the implemented transaction invariants: each attempt opens one
+   connection, sets `autoCommit=false`, executes all operation groups, and
+   commits once; write parallelism is limited to one and Trino query/task retry
+   modes are rejected. Each connector retry opens fresh transactional state.
+   Failure-after-commit behavior is not yet proven, so no at-most-once replay
+   claim is made without an operation-id or staging/finalize design.
+3. Direct UPDATE and MERGE now reject physical primary-key changes before
+   remote mutation with `NOT_SUPPORTED`. Atomic delete+insert remains a
+   possible future extension. See the
    [YQL UPDATE contract](https://ydb.tech/docs/en/yql/reference/syntax/update).
-4. Add focused tests for composite primary keys, a non-unique first visible
-   column, physical-key updates, rollback/close, and fresh-state retries.
+4. Define and test page/request memory limits. The connector retains all input
+   pages until `finish()`, then creates operation-specific pages while the
+   driver retains the corresponding row structs and list parameter. No current
+   bounded-memory or maximum-request-size claim is made.
+5. Extend rollback/close and fresh-state retry tests, including an uncertain
+   commit outcome that must not replay an already committed change.
 
-**Exit criterion:** retain the current green inherited `testMerge*` suite and
-add a bounded-memory benchmark that demonstrates acceptable production-scale
-runtime for the set-based implementation.
+**Exit criterion:** retain the green inherited `testMerge*` suite, cover the
+physical composite-key and rejection contracts, and demonstrate the chosen
+page/request limits with a bounded-memory production-scale benchmark. A safe
+staging/finalize or operation-id design is required before claiming replay-safe
+retries after uncertain commit outcomes.
+
+### Merge-key slice validation (2026-08-20)
+
+GitHub Actions run
+[`32378003537`](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/32378003537)
+at `33bfb8f` reported 338 tests, 0 failures, 0 errors, and 84 skipped. It
+included Connector 288/80, Smoke 36/4, Federation 6/0, TablePath 5/0, and the
+port allocator 3/0. That run verified the physical-key rejection contract and
+the initial cross-sibling fixture. Final review added the complementary
+cross-sibling needed to catch either operation using either individual key;
+the required GitHub Actions check on PR #244 gates that final test-only change.
 
 ## P1 — retry and transaction hardening
 
@@ -201,8 +240,7 @@ runtime for the set-based implementation.
   committed an internal batch.
 - Add unit tests for status classification, interrupted backoff, rollback
   failure suppression, connection cleanup, and a failure after commit.
-- Define memory/backpressure limits for buffered merge pages; memory usage must
-  not remain unreported.
+- Apply and verify the P0 memory/backpressure limits for buffered merge pages.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -19,12 +19,115 @@ have been verified locally against a real YDB test container:
 - retry classification through the YDB SDK status model, with fresh merge
   connections and rollback-before-close.
 
-GitHub Actions is green on PR #240: 314 tests run, 0 failed, 0 errors, 84
-skipped. This includes 36 smoke tests (4 skipped) and 278 connector tests (80
-skipped). The inherited `testMergeLarge` runs without an override and completes
-within the CI budget. An isolated local Colima run previously exceeded 11
-minutes, so MERGE scalability remains a production concern rather than a CI
-failure.
+GitHub Actions on PR #240 verified the DML baseline: 314 tests run, 0 failures,
+0 errors, and 84 skipped. This included 36 smoke tests (4 skipped) and 278
+connector tests (80 skipped). The inherited `testMergeLarge` runs without an
+override and completes within the CI budget. An isolated local Colima run
+previously exceeded 11 minutes, so MERGE scalability remains a production
+concern rather than a CI failure.
+
+Fresh local JDK 25 namespace validation (2026-08-20) reported 327 discovered
+tests: 0 failures, 0 errors, and 84 skipped, leaving 243 executed tests passed.
+It included 5 `TestYdbTablePath` tests, 286 connector tests (80 skipped), and
+36 smoke tests (4 skipped); no other test classes ran.
+
+## Approved namespace and catalog contract
+
+The public namespace model was agreed on 2026-08-19:
+
+- one Trino catalog is one configured YDB connector instance bound
+  to exactly one YDB database through its JDBC `connection-url` and credentials;
+- multiple YDB databases use multiple Trino catalog configurations; the
+  connector does not discover databases or publish catalogs dynamically;
+- the connector exposes exactly one virtual, non-droppable Trino schema named
+  `default`;
+- a Trino table name is the complete YDB object path relative to the configured
+  database root. Root table `orders` is `catalog.default.orders`; nested table
+  `sales/eu/orders` is `catalog.default."sales/eu/orders"`;
+- the configured database path is a connection and security boundary and never
+  becomes part of the Trino schema or table name.
+
+This keeps the native YDB path visible in SQL and avoids flattening directories
+into a list of artificial Trino schemas. Trino schemas are not hierarchical, so
+mapping `sales/eu` to a schema would still appear as one flat, quoted schema in
+SQL clients rather than as a directory tree.
+
+### Metadata and DDL behavior
+
+| Trino operation | Contract |
+| --- | --- |
+| `listSchemaNames()` | Return only `default` |
+| `listTables(Optional.empty())` | Return every accessible YDB table recursively, all in `default` |
+| `listTables(Optional.of("default"))` | Same table set as the unfiltered call |
+| `listTables()` for another schema | Return an empty list |
+| `getTableHandle(default, name)` | Resolve the validated full relative YDB path |
+| `getTableHandle()` for another schema | Return empty without querying an unrelated path |
+| `CREATE`, `DROP`, `RENAME SCHEMA` | `NOT_SUPPORTED`; `default` is virtual and cannot be changed |
+| `CREATE TABLE default."dir/table"` | Require the parent YDB directory to exist |
+| table rename | May move a table by changing its full relative path; target parent must exist |
+
+The connector must parse paths into components before producing YQL. It rejects
+absolute paths, empty components, leading/trailing or repeated `/`, `.` and
+`..`, dot-prefixed/system components, invalid YDB component names, and
+components longer than the 255-character YDB component limit. It does not impose
+an artificial 255-character limit on the complete relative path. The validated
+full path is quoted as one YQL identifier through the connector quoting helper.
+It is not assembled by call-site string concatenation.
+
+Trino 479 normalizes SQL identifiers to lowercase, including delimited
+identifiers. YDB paths are case-sensitive. A lowercase Trino name may resolve to
+one unique case-insensitive remote path; case-only collisions must fail with an
+explicit ambiguous-name error rather than selecting an arbitrary object.
+
+### Catalog provisioning and federation
+
+Static catalog property files are the production default. For example,
+`ydb_prod.properties` and `ydb_analytics.properties` contain separate YDB JDBC
+URLs and expose `ydb_prod.default` and `ydb_analytics.default`. Trino 479 dynamic
+catalog management can optionally create the same connector instances with
+`CREATE CATALOG`, but it is an experimental Trino deployment feature and not
+YDB database discovery by the connector. Sensitive catalog properties must not
+be placed directly in SQL because the complete statement is logged and visible
+in the Trino Web UI.
+
+Federated reads qualify each source by catalog. Cross-catalog joins run in
+Trino; join pushdown requires both tables to belong to the same catalog.
+Trino 479 permits one autocommit statement to read from several catalogs and
+write to one target catalog when the target operation is supported. This
+read-many/write-one YDB topology remains unverified and provides neither a
+cross-catalog snapshot nor a distributed commit.
+
+Cross-catalog reads may run in an explicit transaction. YDB is a
+single-statement-write connector: when YDB is the first or only write target,
+Trino rejects the write before connector mutation with `Catalog only supports
+writes using autocommit: <catalog>`. A read-only transaction or an earlier write
+to another catalog can instead surface the corresponding read-only or
+multi-catalog-write error.
+
+### Implemented namespace slice (verified 2026-08-20)
+
+This slice implements the following items:
+
+1. Introduced one path parser/validator used by metadata and table operations.
+2. Changed the synthetic schema from `ydb` to `default`.
+3. Made `listTables` and `getTableHandle` honor the schema filter and preserve
+   the complete relative YDB table path.
+4. Mapped only genuine remote not-found results to an absent table handle and preserved
+   other JDBC/YDB failures.
+5. Added focused tests for root and nested tables, an unknown schema, path
+   traversal, dot-prefixed paths, case-only ambiguity, and full-path quoting.
+6. Made relation-comment metadata and opt-in bulk column metadata honor the
+   virtual `default` schema, recursive paths, and case-only collision checks.
+   Comment writes remain unsupported, and bulk column metadata remains opt-in.
+
+This slice does not enable schema DDL capabilities or change capability flags.
+Catalog provisioning and cross-catalog federation remain a separate, unverified
+integration slice.
+
+The real-YDB `testNestedTablePathLongerThanSingleComponentLimit` passed in the
+final full suite. It covers a complete relative path longer than 255 characters
+whose components are each at most 255 characters, including listing, selection,
+rename, and cleanup.
 
 ## P0 — harden MERGE scalability and atomicity
 
@@ -85,7 +188,8 @@ need this treatment. YDB `Date` starts at the Unix epoch; see
 
 ## Later capability work
 
-- schema-as-YDB-path design for CREATE/DROP/RENAME SCHEMA;
+- catalog provisioning and YDB-to-YDB federation coverage for the approved
+  single-`default`-schema namespace model;
 - List/Dict/Struct mappings for Trino ARRAY/MAP/ROW;
 - views, comments, rename column, and type changes after checking current YQL
   semantics;

--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -241,11 +241,18 @@ does not replace the inherited real-YDB MERGE suite or the full module suite.
 
 ## P1 — retry and transaction hardening
 
-- Retry only statuses classified as unconditional by the pinned YDB SDK.
-  `TIMEOUT`, `UNDETERMINED`, transport failures, and other conditional statuses
-  are unsafe for non-idempotent writes unless an operation-id/staging design
-  proves replay safety. See
+- Connector-owned MERGE retries use `StatusCode.isRetryable(false)` from the
+  pinned SDK. A focused classification test freezes its current unconditional
+  set: `ABORTED`, `UNAVAILABLE`, `OVERLOADED`, `BAD_SESSION`, `SESSION_BUSY`,
+  and `CLIENT_RESOURCE_EXHAUSTED`. `TIMEOUT`, `UNDETERMINED`,
+  `SESSION_EXPIRED`, transport failures, and other conditional statuses are
+  not retried for non-idempotent writes. See
   [YDB SDK error handling](https://ydb.tech/docs/en/reference/ydb-sdk/error_handling).
+- Removed the generic `BaseJdbcClient.execute` retry wrapper. That hook receives
+  a caller-owned JDBC connection and cannot replace it, while `BAD_SESSION` and
+  `SESSION_BUSY` explicitly require a new session. DDL failures now surface to
+  Trino instead of replaying on the same connection; MERGE retains its separate
+  fresh-connection transaction retry.
 - Keep the JDBC `SessionPool.acquire` scheduler-rejection workaround limited to
   that provably pre-execution stack. Track it against the YDB JDBC driver and
   remove the connector workaround after upgrading to a fixed driver.
@@ -260,6 +267,14 @@ does not replace the inherited real-YDB MERGE suite or the full module suite.
 - Add unit tests for status classification, interrupted backoff, rollback
   failure suppression, connection cleanup, and a failure after commit.
 - Apply and verify the P0 memory/backpressure limits for buffered merge pages.
+
+### Retry-classification slice validation (2026-08-20)
+
+A focused JDK 25 run of `TestYdbRetryUtils` and `TestYdbMergeSink` reported 7
+tests, 0 failures, 0 errors, and 0 skipped without initializing Docker. The
+slice verifies the complete pinned-SDK unconditional status set, nested-cause
+classification, and the existing fresh-connection MERGE lifecycle. It does not
+replace the real-YDB or full module suite.
 
 ## P2 — remove remaining test debt
 

--- a/ydb-trino-adapter/examples/trino/etc/catalog/ydb.properties
+++ b/ydb-trino-adapter/examples/trino/etc/catalog/ydb.properties
@@ -1,2 +1,4 @@
 connector.name=ydb
+# Local single-database example used by examples/docker-compose.yml.
+# Production uses one catalog file per database; see README for secret references.
 connection-url=jdbc:ydb:grpc://ydb-local:2136/local

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -879,6 +879,11 @@ public class YdbClient extends BaseJdbcClient {
         if (primaryKeys.isEmpty()) {
             throw new TrinoException(NOT_SUPPORTED, "The connector cannot perform MERGE on a table without a primary key");
         }
+        rejectPrimaryKeyUpdates(
+                primaryKeys,
+                updateColumnHandles.values().stream()
+                        .flatMap(Collection::stream)
+                        .map(JdbcColumnHandle.class::cast));
 
         SchemaTableName schemaTableName = handle.getRequiredNamedRelation().getSchemaTableName();
         RemoteTableName remoteTableName = handle.getRequiredNamedRelation().getRemoteTableName();
@@ -941,6 +946,16 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public OptionalLong update(ConnectorSession session, JdbcTableHandle handle) {
+        List<JdbcColumnHandle> primaryKeys = getPrimaryKeys(
+                session,
+                handle.getRequiredNamedRelation().getRemoteTableName());
+        if (primaryKeys.isEmpty()) {
+            throw new TrinoException(NOT_SUPPORTED, "YDB DML requires a table primary key");
+        }
+        rejectPrimaryKeyUpdates(
+                primaryKeys,
+                handle.getUpdateAssignments().stream().map(assignment -> assignment.column()));
+
         try (Connection connection = connectionFactory.openConnection(session)) {
             PreparedQuery preparedQuery = queryBuilder.prepareUpdateQuery(
                     this,
@@ -950,7 +965,7 @@ public class YdbClient extends BaseJdbcClient {
                     handle.getConstraint(),
                     getAdditionalPredicate(handle.getConstraintExpressions(), Optional.empty()),
                     handle.getUpdateAssignments());
-            return OptionalLong.of(executeReturningDml(session, connection, handle, preparedQuery));
+            return OptionalLong.of(executeReturningDml(session, connection, preparedQuery, primaryKeys));
         }
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
@@ -968,6 +983,14 @@ public class YdbClient extends BaseJdbcClient {
         if (primaryKeys.isEmpty()) {
             throw new TrinoException(NOT_SUPPORTED, "YDB DML requires a table primary key");
         }
+        return executeReturningDml(session, connection, preparedQuery, primaryKeys);
+    }
+
+    private long executeReturningDml(
+            ConnectorSession session,
+            Connection connection,
+            PreparedQuery preparedQuery,
+            List<JdbcColumnHandle> primaryKeys) throws SQLException {
         PreparedQuery returningQuery = preparedQuery.transformQuery(
                 query -> query + " RETURNING " + quoted(primaryKeys.getFirst().getColumnName()));
 
@@ -979,6 +1002,26 @@ public class YdbClient extends BaseJdbcClient {
             }
         }
         return affectedRows;
+    }
+
+    private static void rejectPrimaryKeyUpdates(
+            List<JdbcColumnHandle> primaryKeys,
+            Stream<JdbcColumnHandle> updatedColumns) {
+        Set<String> updatedColumnNames = updatedColumns
+                .map(JdbcColumnHandle::getColumnName)
+                .collect(Collectors.toSet());
+        List<String> updatedPrimaryKeyNames = primaryKeys.stream()
+                .map(JdbcColumnHandle::getColumnName)
+                .filter(updatedColumnNames::contains)
+                .toList();
+        if (!updatedPrimaryKeyNames.isEmpty()) {
+            String columnLabel = updatedPrimaryKeyNames.size() == 1 ? "column" : "columns";
+            throw new TrinoException(
+                    NOT_SUPPORTED,
+                    "Cannot update YDB primary key %s: %s".formatted(
+                            columnLabel,
+                            String.join(", ", updatedPrimaryKeyNames)));
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -623,11 +623,6 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     @Override
-    protected void execute(ConnectorSession session, Connection connection, String query) throws SQLException {
-        YdbRetryUtils.withRetry(() -> super.execute(session, connection, query));
-    }
-
-    @Override
     public boolean supportsRetries() {
         // Disable Trino-retries to avoid temporary tables.
         return false;

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -707,6 +707,54 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     @Override
+    protected void copyTableSchema(
+            ConnectorSession session,
+            Connection connection,
+            String catalogName,
+            String schemaName,
+            String tableName,
+            String newTableName,
+            List<String> columnNames) {
+        RemoteTableName sourceTable = new RemoteTableName(Optional.empty(), Optional.empty(), tableName);
+        Map<String, JdbcColumnHandle> columnsByName = getColumns(
+                session,
+                new SchemaTableName(DEFAULT_SCHEMA, tableName),
+                sourceTable).stream()
+                .collect(Collectors.toMap(JdbcColumnHandle::getColumnName, Function.identity()));
+
+        String stagingKey = nonRepeatNames("_trino_staging_id", columnNames);
+        ImmutableList.Builder<String> columnDefinitions = ImmutableList.builder();
+        columnDefinitions.add(quoted(stagingKey) + " BigSerial");
+        for (String columnName : columnNames) {
+            JdbcColumnHandle column = Optional.ofNullable(columnsByName.get(columnName))
+                    .orElseThrow(() -> new TrinoException(
+                            JDBC_ERROR,
+                            "Cannot create YDB INSERT staging table: source column not found: " + columnName));
+            String remoteType = column.getJdbcTypeHandle().jdbcTypeName()
+                    .orElseThrow(() -> new TrinoException(
+                            JDBC_ERROR,
+                            "Cannot create YDB INSERT staging table: JDBC type name is missing for " + columnName));
+            columnDefinitions.add(format(
+                    "%s %s%s",
+                    quoted(columnName),
+                    remoteType,
+                    column.isNullable() ? "" : " NOT NULL"));
+        }
+
+        String sql = format(
+                "CREATE TABLE %s (%s, PRIMARY KEY (%s))",
+                quoted(newTableName),
+                String.join(", ", columnDefinitions.build()),
+                quoted(stagingKey));
+        try {
+            execute(session, connection, sql);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to create YDB INSERT staging table", e);
+        }
+    }
+
+    @Override
     public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName) {
         YdbTablePath destination = YdbTablePath.fromUserInput(newTableName.getTableName());
         SchemaTableName currentName = handle.asPlainTable().getSchemaTableName();

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -24,7 +24,10 @@ import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcSortItem;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.LongReadFunction;
+import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.PredicatePushdownController;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -43,6 +46,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ColumnPosition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.RelationColumnsMetadata;
@@ -51,8 +55,8 @@ import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.expression.ConnectorExpression;
-import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -64,6 +68,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -90,8 +96,6 @@ import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
-import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.dateWriteFunctionUsingLocalDate;
 import static io.trino.plugin.jdbc.StandardColumnMappings.dateReadFunctionUsingLocalDate;
 import static io.trino.plugin.jdbc.StandardColumnMappings.decimalColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.doubleColumnMapping;
@@ -104,9 +108,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.fromTrinoTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampReadFunction;
-import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
@@ -122,18 +125,58 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.sql.DatabaseMetaData.columnNoNulls;
+import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.joining;
+import static tech.ydb.jdbc.YdbConst.SQL_KIND_PRIMITIVE;
 
 public class YdbClient extends BaseJdbcClient {
     static final String DEFAULT_SCHEMA = "default";
     private static final int YDB_DEFAULT_DECIMAL_PRECISION = 22;
     private static final int YDB_DEFAULT_DECIMAL_SCALE = 9;
+    private static final int YDB_DATE_TYPE = SQL_KIND_PRIMITIVE + 16;
+    private static final int YDB_DATETIME_TYPE = SQL_KIND_PRIMITIVE + 17;
+    private static final int YDB_TIMESTAMP_TYPE = SQL_KIND_PRIMITIVE + 18;
+    private static final int YDB_DATE32_TYPE = SQL_KIND_PRIMITIVE + 25;
+    private static final int YDB_DATETIME64_TYPE = SQL_KIND_PRIMITIVE + 26;
+    private static final int YDB_TIMESTAMP64_TYPE = SQL_KIND_PRIMITIVE + 27;
+    private static final TimestampType TIMESTAMP_SECONDS = createTimestampType(0);
+    private static final long YDB_DATE_MIN_EPOCH_DAY = LocalDate.of(1970, 1, 1).toEpochDay();
+    private static final long YDB_DATE_MAX_EPOCH_DAY_EXCLUSIVE = LocalDate.of(2106, 1, 1).toEpochDay();
+    private static final long YDB_SIGNED_DATE_MIN_EPOCH_DAY = LocalDate.of(-144168, 1, 1).toEpochDay();
+    private static final long YDB_SIGNED_DATE_MAX_EPOCH_DAY_EXCLUSIVE = LocalDate.of(148108, 1, 1).toEpochDay();
+    private static final long YDB_TIMESTAMP_MIN_EPOCH_MICRO = 0;
+    private static final long YDB_TIMESTAMP_MAX_EPOCH_MICRO_EXCLUSIVE = 4_291_747_200_000_000L;
+    private static final long YDB_SIGNED_TIMESTAMP_MIN_EPOCH_MICRO = -4_611_669_897_600_000_000L;
+    private static final long YDB_SIGNED_TIMESTAMP_MAX_EPOCH_MICRO_EXCLUSIVE = 4_611_669_811_199_999_999L;
+    private static final PredicatePushdownController YDB_DATE_PUSHDOWN = rangePushdown(
+            YDB_DATE_MIN_EPOCH_DAY,
+            YDB_DATE_MAX_EPOCH_DAY_EXCLUSIVE);
+    private static final PredicatePushdownController YDB_SIGNED_DATE_PUSHDOWN = rangePushdown(
+            YDB_SIGNED_DATE_MIN_EPOCH_DAY,
+            YDB_SIGNED_DATE_MAX_EPOCH_DAY_EXCLUSIVE);
+    private static final PredicatePushdownController YDB_TIMESTAMP_PUSHDOWN = rangePushdown(
+            YDB_TIMESTAMP_MIN_EPOCH_MICRO,
+            YDB_TIMESTAMP_MAX_EPOCH_MICRO_EXCLUSIVE);
+    private static final PredicatePushdownController YDB_SIGNED_TIMESTAMP_PUSHDOWN = rangePushdown(
+            YDB_SIGNED_TIMESTAMP_MIN_EPOCH_MICRO,
+            YDB_SIGNED_TIMESTAMP_MAX_EPOCH_MICRO_EXCLUSIVE);
+
+    private static PredicatePushdownController rangePushdown(long minimum, long maximumExclusive) {
+        return (session, domain) -> {
+            boolean hasUnsupportedBound = domain.getValues().getRanges().getOrderedRanges().stream()
+                    .flatMap(range -> Stream.concat(range.getLowValue().stream(), range.getHighValue().stream()))
+                    .map(Long.class::cast)
+                    .anyMatch(value -> value < minimum || value >= maximumExclusive);
+            return (hasUnsupportedBound ? DISABLE_PUSHDOWN : FULL_PUSHDOWN).apply(session, domain);
+        };
+    }
 
     private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, ParameterizedExpression> aggregateFunctionRewriter;
@@ -473,8 +516,8 @@ public class YdbClient extends BaseJdbcClient {
                         : typeHandle.columnSize().orElse(VarcharType.MAX_LENGTH);
                 yield Optional.of(varcharColumnMapping(length));
             }
-            case Types.DATE -> Optional.of(dateColumnMapping());
-            case Types.TIMESTAMP -> Optional.of(timestampColumnMapping());
+            case Types.DATE -> Optional.of(dateColumnMapping(typeHandle.jdbcTypeName().orElse("Date")));
+            case Types.TIMESTAMP -> Optional.of(timestampColumnMapping(typeHandle.jdbcTypeName().orElse("Timestamp")));
             default -> Optional.empty();
         };
 
@@ -505,18 +548,60 @@ public class YdbClient extends BaseJdbcClient {
                 FULL_PUSHDOWN);
     }
 
-    private static ColumnMapping dateColumnMapping() {
+    static ColumnMapping dateColumnMapping(String typeName) {
+        boolean signed = typeName.equalsIgnoreCase("Date32");
+        int jdbcType = signed ? YDB_DATE32_TYPE : YDB_DATE_TYPE;
         return ColumnMapping.longMapping(
                 DATE,
                 dateReadFunctionUsingLocalDate(),
-                dateWriteFunctionUsingLocalDate());
+                dateWriteFunction(jdbcType),
+                signed ? YDB_SIGNED_DATE_PUSHDOWN : YDB_DATE_PUSHDOWN);
     }
 
-    private static ColumnMapping timestampColumnMapping() {
+    private static LongWriteFunction dateWriteFunction(int jdbcType) {
+        return LongWriteFunction.of(jdbcType, (statement, index, value) ->
+                statement.setObject(index, LocalDate.ofEpochDay(value), jdbcType));
+    }
+
+    static ColumnMapping timestampColumnMapping(String typeName) {
+        return switch (typeName.toLowerCase(Locale.ENGLISH)) {
+            case "datetime" -> datetimeColumnMapping(YDB_DATETIME_TYPE, YDB_TIMESTAMP_PUSHDOWN);
+            case "datetime64" -> datetimeColumnMapping(YDB_DATETIME64_TYPE, YDB_SIGNED_TIMESTAMP_PUSHDOWN);
+            case "timestamp64" -> timestampColumnMapping(YDB_TIMESTAMP64_TYPE, YDB_SIGNED_TIMESTAMP_PUSHDOWN);
+            default -> timestampColumnMapping(YDB_TIMESTAMP_TYPE, YDB_TIMESTAMP_PUSHDOWN);
+        };
+    }
+
+    private static ColumnMapping datetimeColumnMapping(
+            int jdbcType,
+            PredicatePushdownController predicatePushdownController) {
+        return ColumnMapping.longMapping(
+                TIMESTAMP_SECONDS,
+                timestampReadFunction(TIMESTAMP_SECONDS),
+                LongWriteFunction.of(jdbcType, (statement, index, value) ->
+                        statement.setObject(index, fromTrinoTimestamp(value), jdbcType)),
+                predicatePushdownController);
+    }
+
+    private static ColumnMapping timestampColumnMapping(
+            int jdbcType,
+            PredicatePushdownController predicatePushdownController) {
+        LongReadFunction readFunction = (resultSet, columnIndex) -> {
+            Instant value = resultSet.getObject(columnIndex, Instant.class);
+            return Math.addExact(
+                    Math.multiplyExact(value.getEpochSecond(), 1_000_000),
+                    value.getNano() / 1_000);
+        };
         return ColumnMapping.longMapping(
                 TIMESTAMP_MICROS,
-                timestampReadFunction(TIMESTAMP_MICROS),
-                timestampWriteFunction(TIMESTAMP_MICROS));
+                readFunction,
+                timestampWriteFunction(jdbcType),
+                predicatePushdownController);
+    }
+
+    private static LongWriteFunction timestampWriteFunction(int jdbcType) {
+        return LongWriteFunction.of(jdbcType, (statement, index, value) ->
+                statement.setObject(index, fromTrinoTimestamp(value).toInstant(UTC), jdbcType));
     }
 
     @Override
@@ -551,14 +636,11 @@ public class YdbClient extends BaseJdbcClient {
         if (type instanceof VarcharType) {
             return WriteMapping.sliceMapping("Text", varcharWriteFunction());
         }
-        if (type instanceof CharType) {
-            return WriteMapping.sliceMapping("Text", charWriteFunction());
-        }
         if (type == DATE) {
-            return WriteMapping.longMapping("Date", dateWriteFunctionUsingLocalDate());
+            return WriteMapping.longMapping("Date32", dateWriteFunction(YDB_DATE32_TYPE));
         }
         if (type == TIMESTAMP_MICROS) {
-            return WriteMapping.longMapping("Timestamp", timestampWriteFunction(TIMESTAMP_MICROS));
+            return WriteMapping.longMapping("Timestamp64", timestampWriteFunction(YDB_TIMESTAMP64_TYPE));
         }
 
         throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type);
@@ -839,6 +921,36 @@ public class YdbClient extends BaseJdbcClient {
                 quoted(table),
                 getColumnDefinitionSql(session, column, remoteColumnName));
         execute(session, connection, sql);
+    }
+
+    @Override
+    public void addColumn(
+            ConnectorSession session,
+            JdbcTableHandle handle,
+            ColumnMetadata column,
+            ColumnPosition position
+    ) {
+        int maxAttempts = 10;
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                super.addColumn(session, handle, column, position);
+                return;
+            }
+            catch (RuntimeException e) {
+                if (!YdbRetryUtils.isRetryable(e) || attempt == maxAttempts - 1) {
+                    throw e;
+                }
+
+                try {
+                    Thread.sleep(YdbRetryUtils.calculateBackoff(attempt));
+                }
+                catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    e.addSuppressed(interrupted);
+                    throw new TrinoException(JDBC_ERROR, "Interrupted while waiting to retry YDB ADD COLUMN", e);
+                }
+            }
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -45,6 +45,8 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.RelationColumnsMetadata;
+import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortOrder;
@@ -55,7 +57,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import jakarta.annotation.Nullable;
-import org.jspecify.annotations.NonNull;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -64,6 +65,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -73,11 +76,13 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.jdbc.DefaultJdbcMetadata.MERGE_ROW_ID;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
@@ -106,6 +111,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.spi.StandardErrorCode.AMBIGUOUS_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -121,10 +127,11 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Math.max;
 import static java.lang.String.format;
+import static java.sql.DatabaseMetaData.columnNoNulls;
 import static java.util.stream.Collectors.joining;
 
 public class YdbClient extends BaseJdbcClient {
-    private static final String YDB_SCHEMA = "ydb";
+    static final String DEFAULT_SCHEMA = "default";
     private static final int YDB_DEFAULT_DECIMAL_PRECISION = 22;
     private static final int YDB_DEFAULT_DECIMAL_SCALE = 9;
 
@@ -240,7 +247,7 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public Collection<String> listSchemas(Connection connection) {
-        return ImmutableSet.of(YDB_SCHEMA);
+        return ImmutableSet.of(DEFAULT_SCHEMA);
     }
 
     @Override
@@ -250,17 +257,87 @@ public class YdbClient extends BaseJdbcClient {
 
     @Override
     public List<SchemaTableName> getTableNames(ConnectorSession session, Optional<String> schema) {
+        if (schema.isPresent() && !DEFAULT_SCHEMA.equalsIgnoreCase(schema.get())) {
+            return ImmutableList.of();
+        }
+
         try (Connection connection = connectionFactory.openConnection(session)) {
-            try (ResultSet resultSet = getTables(connection, Optional.empty(), Optional.empty())) {
-                ImmutableList.Builder<@NonNull SchemaTableName> list = ImmutableList.builder();
-                while (resultSet.next()) {
-                    String tableName = resultSet.getString("TABLE_NAME");
-                    list.add(new SchemaTableName(YDB_SCHEMA, tableName));
-                }
-                return list.build();
-            }
+            List<YdbTablePath> paths = listRemoteTablePaths(connection);
+            throwIfAmbiguous(paths);
+            return paths.stream()
+                    .distinct()
+                    .map(path -> new SchemaTableName(DEFAULT_SCHEMA, path.value()))
+                    .collect(Collectors.toList());
         } catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
+            throw new TrinoException(JDBC_ERROR, "Failed to list YDB tables", e);
+        }
+    }
+
+    @Override
+    public List<RelationCommentMetadata> getAllTableComments(ConnectorSession session, Optional<String> schema) {
+        return getTableNames(session, schema).stream()
+                .map(table -> RelationCommentMetadata.forRelation(table, Optional.empty()))
+                .toList();
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> getAllTableColumns(ConnectorSession session, Optional<String> schema) {
+        if (schema.isPresent() && !DEFAULT_SCHEMA.equalsIgnoreCase(schema.get())) {
+            return ImmutableList.<RelationColumnsMetadata>of().iterator();
+        }
+
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            List<YdbTablePath> paths = listRemoteTablePaths(connection);
+            throwIfAmbiguous(paths);
+
+            Map<String, ImmutableList.Builder<ColumnMetadata>> columnsByTable = new LinkedHashMap<>();
+            paths.stream()
+                    .distinct()
+                    .forEach(path -> columnsByTable.put(path.value(), ImmutableList.builder()));
+
+            DatabaseMetaData metadata = connection.getMetaData();
+            try (ResultSet resultSet = metadata.getColumns(connection.getCatalog(), null, null, null)) {
+                while (resultSet.next()) {
+                    ImmutableList.Builder<ColumnMetadata> columns = columnsByTable.get(resultSet.getString("TABLE_NAME"));
+                    if (columns == null) {
+                        continue;
+                    }
+
+                    String columnName = resultSet.getString("COLUMN_NAME");
+                    JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                            getInteger(resultSet, "DATA_TYPE").orElseThrow(() -> new IllegalStateException("DATA_TYPE is null")),
+                            Optional.ofNullable(resultSet.getString("TYPE_NAME")),
+                            getInteger(resultSet, "COLUMN_SIZE"),
+                            getInteger(resultSet, "DECIMAL_DIGITS"),
+                            Optional.empty(),
+                            Optional.empty());
+                    boolean nullable = resultSet.getInt("NULLABLE") != columnNoNulls;
+                    Optional<String> comment = Optional.ofNullable(resultSet.getString("REMARKS"))
+                            .filter(value -> !value.isEmpty());
+                    toColumnMapping(session, connection, typeHandle).ifPresent(mapping -> columns.add(
+                            JdbcColumnHandle.builder()
+                                    .setColumnName(columnName)
+                                    .setJdbcTypeHandle(typeHandle)
+                                    .setColumnType(mapping.getType())
+                                    .setNullable(nullable)
+                                    .setComment(comment)
+                                    .build()
+                                    .getColumnMetadata()));
+                }
+            }
+
+            ImmutableList.Builder<RelationColumnsMetadata> relations = ImmutableList.builder();
+            columnsByTable.forEach((table, columnsBuilder) -> {
+                List<ColumnMetadata> columns = columnsBuilder.build();
+                if (!columns.isEmpty()) {
+                    relations.add(RelationColumnsMetadata.forTable(
+                            new SchemaTableName(DEFAULT_SCHEMA, table),
+                            columns));
+                }
+            });
+            return relations.build().iterator();
+        } catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to list YDB table columns", e);
         }
     }
 
@@ -269,21 +346,62 @@ public class YdbClient extends BaseJdbcClient {
             ConnectorSession session,
             SchemaTableName schemaTableName
     ) {
-        try (Connection connection = connectionFactory.openConnection(session)) {
-            RemoteTableName remoteTableName = toRemoteTableName(schemaTableName);
-            try (ResultSet columns = getColumns(remoteTableName, connection.getMetaData())) {
-                if (!columns.next()) {
-                    return Optional.empty();
-                }
-            }
-            return Optional.of(new JdbcTableHandle(
-                    new SchemaTableName(YDB_SCHEMA, schemaTableName.getTableName()),
-                    remoteTableName,
-                    Optional.empty())
-            );
-        } catch (SQLException e) {
+        if (!DEFAULT_SCHEMA.equalsIgnoreCase(schemaTableName.getSchemaName())) {
             return Optional.empty();
         }
+        if (YdbTablePath.isDataSystemTableName(schemaTableName.getTableName())) {
+            return Optional.empty();
+        }
+
+        YdbTablePath requestedPath = YdbTablePath.fromUserInput(schemaTableName.getTableName());
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            return resolveRemoteTablePath(connection, requestedPath)
+                    .map(remotePath -> new JdbcTableHandle(
+                            new SchemaTableName(DEFAULT_SCHEMA, schemaTableName.getTableName()),
+                            new RemoteTableName(Optional.empty(), Optional.empty(), remotePath.value()),
+                            Optional.empty()));
+        } catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to resolve YDB table " + schemaTableName, e);
+        }
+    }
+
+    private List<YdbTablePath> listRemoteTablePaths(Connection connection)
+            throws SQLException
+    {
+        ImmutableList.Builder<YdbTablePath> paths = ImmutableList.builder();
+        try (ResultSet resultSet = getTables(connection, Optional.empty(), Optional.empty())) {
+            while (resultSet.next()) {
+                YdbTablePath.fromRemoteMetadata(resultSet.getString("TABLE_NAME"))
+                        .ifPresent(paths::add);
+            }
+        }
+        return paths.build();
+    }
+
+    private Optional<YdbTablePath> resolveRemoteTablePath(Connection connection, YdbTablePath requestedPath)
+            throws SQLException
+    {
+        List<YdbTablePath> matches = listRemoteTablePaths(connection).stream()
+                .filter(path -> path.comparisonKey().equals(requestedPath.comparisonKey()))
+                .distinct()
+                .toList();
+        throwIfAmbiguous(matches);
+        return matches.stream().findFirst();
+    }
+
+    private static void throwIfAmbiguous(List<YdbTablePath> paths)
+    {
+        Map<String, Set<String>> valuesByComparisonKey = paths.stream()
+                .collect(Collectors.groupingBy(
+                        YdbTablePath::comparisonKey,
+                        TreeMap::new,
+                        Collectors.mapping(YdbTablePath::value, Collectors.toCollection(TreeSet::new))));
+        valuesByComparisonKey.values().stream()
+                .filter(values -> values.size() > 1)
+                .findFirst()
+                .ifPresent(values -> {
+                    throw new TrinoException(AMBIGUOUS_NAME, "Ambiguous YDB table path: " + values);
+                });
     }
 
     @Override
@@ -494,13 +612,14 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     private RemoteTableName toRemoteTableName(SchemaTableName schemaTableName) {
-        return new RemoteTableName(Optional.empty(), Optional.empty(), schemaTableName.getTableName());
+        String tableName = YdbTablePath.fromUserInput(schemaTableName.getTableName()).value();
+        return new RemoteTableName(Optional.empty(), Optional.empty(), tableName);
     }
 
     @Override
     protected String quoted(@Nullable String catalog, @Nullable String schema, String table) {
         // YDB doesn't use catalog & schema in table names, only the table path
-        return quoted(table);
+        return quoted(YdbTablePath.fromUserInput(table).value());
     }
 
     @Override
@@ -566,12 +685,59 @@ public class YdbClient extends BaseJdbcClient {
     }
 
     @Override
+    public JdbcOutputTableHandle beginInsertTable(
+            ConnectorSession session,
+            JdbcTableHandle tableHandle,
+            List<JdbcColumnHandle> columns)
+    {
+        verify(tableHandle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s", tableHandle);
+        RemoteTableName remoteTableName = tableHandle.asPlainTable().getRemoteTableName();
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            verify(connection.getAutoCommit());
+            String catalogName = remoteTableName.getCatalogName().isPresent()
+                    ? remoteTableName.getCatalogName().orElseThrow()
+                    : connection.getCatalog();
+            return beginInsertTable(
+                    session,
+                    connection,
+                    getRemoteIdentifiers(connection),
+                    catalogName,
+                    DEFAULT_SCHEMA,
+                    remoteTableName.getTableName(),
+                    columns);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
     public void renameTable(ConnectorSession session, JdbcTableHandle handle, SchemaTableName newTableName) {
+        YdbTablePath destination = YdbTablePath.fromUserInput(newTableName.getTableName());
         SchemaTableName currentName = handle.asPlainTable().getSchemaTableName();
         if (!currentName.getSchemaName().equalsIgnoreCase(newTableName.getSchemaName())) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming tables across schemas");
         }
-        super.renameTable(session, handle, newTableName);
+
+        verify(handle.getAuthorization().isEmpty(), "Unexpected authorization is required for table: %s", handle);
+        RemoteTableName remoteTableName = handle.asPlainTable().getRemoteTableName();
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            verify(connection.getAutoCommit());
+            String catalogName = remoteTableName.getCatalogName().isPresent()
+                    ? remoteTableName.getCatalogName().orElseThrow()
+                    : connection.getCatalog();
+            renameTable(
+                    session,
+                    connection,
+                    catalogName,
+                    remoteTableName.getSchemaName().orElse(null),
+                    remoteTableName.getTableName(),
+                    null,
+                    destination.value());
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
     }
 
     @Override
@@ -648,7 +814,7 @@ public class YdbClient extends BaseJdbcClient {
         String tableName = remoteTableName.getTableName();
         String metadataSchemaName = remoteTableName.getSchemaName().orElse(null);
         SchemaTableName schemaTableName = new SchemaTableName(
-                remoteTableName.getSchemaName().orElse(YDB_SCHEMA),
+                remoteTableName.getSchemaName().orElse(DEFAULT_SCHEMA),
                 tableName);
         List<JdbcColumnHandle> columns = getColumnsForPrimaryKeyLookup(session, schemaTableName, remoteTableName);
         Map<String, JdbcColumnHandle> columnsByName = columns.stream()

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClientModule.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClientModule.java
@@ -20,6 +20,7 @@ import tech.ydb.jdbc.YdbDriver;
 import java.util.Properties;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class YdbClientModule implements Module {
 
@@ -32,6 +33,7 @@ public class YdbClientModule implements Module {
 
         binder.bind(YdbPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(YdbConnector.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(YdbConfig.class);
     }
 
     @Provides
@@ -55,6 +57,7 @@ public class YdbClientModule implements Module {
         Properties connectionProperties = new Properties();
         // Avoid the YDB JDBC 2.3.18 shared-context close/register race under concurrent connections.
         connectionProperties.setProperty("cacheConnectionsInDriver", "false");
+        connectionProperties.setProperty("forceSignedDatetimes", "true");
         return DriverConnectionFactory.builder(
                         new YdbDriver(),
                         config.getConnectionUrl(),

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbConfig.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbConfig.java
@@ -1,0 +1,27 @@
+package tech.ydb.trino;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.MinDataSize;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class YdbConfig
+{
+    private DataSize mergeMaxBufferSize = DataSize.of(64, MEGABYTE);
+
+    @MinDataSize("1B")
+    public DataSize getMergeMaxBufferSize()
+    {
+        return mergeMaxBufferSize;
+    }
+
+    @Config("merge.max-buffer-size")
+    @ConfigDescription("Maximum retained memory for a single atomic YDB MERGE sink")
+    public YdbConfig setMergeMaxBufferSize(DataSize mergeMaxBufferSize)
+    {
+        this.mergeMaxBufferSize = mergeMaxBufferSize;
+        return this;
+    }
+}

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbConnector.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbConnector.java
@@ -6,7 +6,10 @@ import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.jdbc.JdbcConnector;
 import io.trino.plugin.jdbc.JdbcTransactionManager;
 import io.trino.plugin.jdbc.TablePropertiesProvider;
-import io.trino.spi.connector.*;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
 
@@ -16,7 +19,6 @@ import java.util.Set;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 
-@SuppressWarnings("all")
 public class YdbConnector extends JdbcConnector {
     @Inject
     public YdbConnector(

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
@@ -38,9 +38,11 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.getWriteBatchSize;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -59,8 +61,10 @@ public class YdbMergeSink implements ConnectorMergeSink {
     private final ConnectorPageSinkId pageSinkId;
     private final RemoteQueryModifier remoteQueryModifier;
     private final int maxBatchSize;
+    private final long maxBufferedBytes;
 
     private final List<Page> bufferedPages = new ArrayList<>();
+    private long bufferedBytes;
     private boolean finished = false;
 
     public YdbMergeSink(
@@ -70,14 +74,17 @@ public class YdbMergeSink implements ConnectorMergeSink {
             JdbcClient jdbcClient,
             ConnectorPageSinkId pageSinkId,
             RemoteQueryModifier remoteQueryModifier,
-            @SuppressWarnings("unused") QueryBuilder queryBuilder
+            @SuppressWarnings("unused") QueryBuilder queryBuilder,
+            long maxBufferedBytes
     ) {
+        checkArgument(maxBufferedBytes > 0, "maxBufferedBytes must be greater than zero");
         this.session = session;
         this.mergeHandle = (JdbcMergeTableHandle) mergeTableHandle;
         this.jdbcClient = jdbcClient;
         this.pageSinkId = pageSinkId;
         this.remoteQueryModifier = remoteQueryModifier;
         this.maxBatchSize = getWriteBatchSize(session);
+        this.maxBufferedBytes = maxBufferedBytes;
     }
 
     @Override
@@ -85,17 +92,29 @@ public class YdbMergeSink implements ConnectorMergeSink {
         if (finished) {
             throw new IllegalStateException();
         }
+        long retainedBytes = page.getRetainedSizeInBytes();
+        if (retainedBytes > maxBufferedBytes - bufferedBytes) {
+            finished = true;
+            clearBufferedPages();
+            throw new TrinoException(
+                    EXCEEDED_LOCAL_MEMORY_LIMIT,
+                    "YDB MERGE buffered input exceeds merge.max-buffer-size of " + maxBufferedBytes + " bytes");
+        }
         bufferedPages.add(page);
+        bufferedBytes += retainedBytes;
     }
 
     @Override
     public CompletableFuture<Collection<Slice>> finish() {
+        if (finished) {
+            throw new IllegalStateException();
+        }
         finished = true;
         try {
             return finishWithRetry();
         }
         finally {
-            bufferedPages.clear();
+            clearBufferedPages();
         }
     }
 
@@ -113,8 +132,9 @@ public class YdbMergeSink implements ConnectorMergeSink {
                 commitAttempted = true;
                 connection.commit();
                 committed = true;
-                connection.close();
+                Connection committedConnection = connection;
                 connection = null;
+                committedConnection.close();
 
                 Slice value = Slices.allocate(Long.BYTES);
                 value.setLong(0, pageSinkId.getId());
@@ -508,6 +528,11 @@ public class YdbMergeSink implements ConnectorMergeSink {
     @Override
     public void abort() {
         finished = true;
+        clearBufferedPages();
+    }
+
+    private void clearBufferedPages() {
         bufferedPages.clear();
+        bufferedBytes = 0;
     }
 }

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
@@ -32,16 +32,15 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.plugin.jdbc.JdbcWriteSessionProperties.getWriteBatchSize;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -49,8 +48,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 /*
   Code partly borrowed from JdbcMergeSink. Key differences are:
   - We do not write into the target table on each storeMergedRows call; instead, we store the necessary pages
-    and write everything at once when finish() is called. Without it, I had serious atomicity problems and flaky tests.
-  - We retry in case YDB returns a retryable exception on an update attempt.
+    and apply them in one transaction when finish() is called. Without it, I had serious atomicity problems and flaky tests.
+  - We retry the complete transaction after a retryable pre-commit YDB failure.
   - We do not use temporary tables unlike base Trino implementation, but write straight to YDB target.
  */
 public class YdbMergeSink implements ConnectorMergeSink {
@@ -59,6 +58,7 @@ public class YdbMergeSink implements ConnectorMergeSink {
     private final JdbcClient jdbcClient;
     private final ConnectorPageSinkId pageSinkId;
     private final RemoteQueryModifier remoteQueryModifier;
+    private final int maxBatchSize;
 
     private final List<Page> bufferedPages = new ArrayList<>();
     private boolean finished = false;
@@ -77,6 +77,7 @@ public class YdbMergeSink implements ConnectorMergeSink {
         this.jdbcClient = jdbcClient;
         this.pageSinkId = pageSinkId;
         this.remoteQueryModifier = remoteQueryModifier;
+        this.maxBatchSize = getWriteBatchSize(session);
     }
 
     @Override
@@ -90,7 +91,15 @@ public class YdbMergeSink implements ConnectorMergeSink {
     @Override
     public CompletableFuture<Collection<Slice>> finish() {
         finished = true;
+        try {
+            return finishWithRetry();
+        }
+        finally {
+            bufferedPages.clear();
+        }
+    }
 
+    private CompletableFuture<Collection<Slice>> finishWithRetry() {
         int maxAttempts = 10;
         Exception lastException = null;
 
@@ -182,36 +191,24 @@ public class YdbMergeSink implements ConnectorMergeSink {
     private void executeMergeInTransaction(Connection connection) throws SQLException {
         JdbcOutputTableHandle outputHandle = mergeHandle.getOutputTableHandle();
         List<JdbcColumnHandle> primaryKeys = mergeHandle.getPrimaryKeys();
-
         int columnCount = outputHandle.getColumnNames().size();
         List<JdbcColumnHandle> columns = mergeHandle.getDataColumns();
 
-        List<Page> insertPages = new ArrayList<>();
-        List<Page> deletePages = new ArrayList<>();
-        Map<Integer, List<Page>> updatePagesByCase = new HashMap<>();
-
-        for (Page page : bufferedPages) {
-            separateMergeOperations(page, columnCount, insertPages, deletePages, updatePagesByCase, columns);
-        }
-
-        if (!deletePages.isEmpty()) {
-            executeDeleteOperations(connection, deletePages, primaryKeys);
-        }
-
-        if (!updatePagesByCase.isEmpty()) {
-            executeUpdateOperations(connection, updatePagesByCase, primaryKeys, columns);
-        }
-
-        if (!insertPages.isEmpty()) {
-            executeInsertOperations(connection, insertPages, outputHandle);
-        }
+        validateMergeOperations(columnCount);
+        executeDeleteOperations(connection, primaryKeys, columnCount);
+        executeUpdateOperations(connection, primaryKeys, columns, columnCount);
+        executeInsertOperations(connection, outputHandle, columnCount);
     }
 
     private void executeDeleteOperations(
             Connection connection,
-            List<Page> deletePages,
-            List<JdbcColumnHandle> primaryKeys
+            List<JdbcColumnHandle> primaryKeys,
+            int columnCount
     ) throws SQLException {
+        if (!containsOperation(columnCount, DELETE_OPERATION_NUMBER)) {
+            return;
+        }
+
         String tableName = mergeHandle.getTableHandle().getRequiredNamedRelation().getRemoteTableName().getTableName();
         StringBuilder deleteSql = new StringBuilder("DELETE FROM ");
         deleteSql.append(jdbcClient.quoted(tableName));
@@ -227,37 +224,59 @@ public class YdbMergeSink implements ConnectorMergeSink {
         }
 
         String sql = remoteQueryModifier.apply(session, deleteSql.toString());
+        List<Type> primaryKeyTypes = primaryKeys.stream()
+                .map(JdbcColumnHandle::getColumnType)
+                .toList();
+        List<WriteFunction> primaryKeyWriters = getColumnWriters(primaryKeyTypes);
 
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            for (Page page : deletePages) {
+            int batchSize = 0;
+            for (Page page : bufferedPages) {
+                Block operationBlock = page.getBlock(columnCount);
+                List<Block> rowIdFields = null;
                 for (int pos = 0; pos < page.getPositionCount(); pos++) {
-                    for (int i = 0; i < primaryKeys.size(); i++) {
-                        Block block = page.getBlock(i);
-                        Type type = primaryKeys.get(i).getColumnType();
-                        WriteFunction writer = jdbcClient.toWriteMapping(session, type).getWriteFunction();
-                        setParameter(stmt, i + 1, block, pos, type, writer);
+                    if (TINYINT.getByte(operationBlock, pos) != DELETE_OPERATION_NUMBER) {
+                        continue;
                     }
-                    stmt.addBatch();
+                    if (rowIdFields == null) {
+                        rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 2));
+                    }
+                    for (int i = 0; i < primaryKeys.size(); i++) {
+                        setParameter(
+                                stmt,
+                                i + 1,
+                                rowIdFields.get(i),
+                                pos,
+                                primaryKeyTypes.get(i),
+                                primaryKeyWriters.get(i));
+                    }
+                    batchSize = addToBatch(stmt, batchSize);
                 }
             }
-            stmt.executeBatch();
+            executeRemainingBatch(stmt, batchSize);
         }
     }
 
     private void executeUpdateOperations(
             Connection connection,
-            Map<Integer, List<Page>> updatePagesByCase,
             List<JdbcColumnHandle> primaryKeys,
-            List<JdbcColumnHandle> columns
+            List<JdbcColumnHandle> columns,
+            int columnCount
     ) throws SQLException {
+        if (!containsOperation(columnCount, UPDATE_OPERATION_NUMBER)) {
+            return;
+        }
+
         String tableName = mergeHandle.getTableHandle().getRequiredNamedRelation().getRemoteTableName().getTableName();
+        List<Type> primaryKeyTypes = primaryKeys.stream()
+                .map(JdbcColumnHandle::getColumnType)
+                .toList();
+        List<WriteFunction> primaryKeyWriters = getColumnWriters(primaryKeyTypes);
 
-        for (Map.Entry<Integer, List<Page>> entry : updatePagesByCase.entrySet()) {
+        for (Map.Entry<Integer, Collection<ColumnHandle>> entry : mergeHandle.getUpdateCaseColumns().entrySet()) {
             int caseNumber = entry.getKey();
-            List<Page> pages = entry.getValue();
-
-            Collection<ColumnHandle> updateColumns = mergeHandle.getUpdateCaseColumns().get(caseNumber);
-            if (updateColumns == null || updateColumns.isEmpty()) {
+            Collection<ColumnHandle> updateColumns = entry.getValue();
+            if (updateColumns == null || updateColumns.isEmpty() || !containsUpdateCase(columnCount, caseNumber)) {
                 continue;
             }
 
@@ -270,9 +289,11 @@ public class YdbMergeSink implements ConnectorMergeSink {
                     .map(columns::indexOf)
                     .collect(toImmutableSet());
 
+            List<Integer> updateChannels = new ArrayList<>();
             List<JdbcColumnHandle> updateColumnList = new ArrayList<>();
             for (int channel = 0; channel < columns.size(); channel++) {
                 if (updateChannelsSet.contains(channel)) {
+                    updateChannels.add(channel);
                     updateColumnList.add(columns.get(channel));
                 }
             }
@@ -297,145 +318,151 @@ public class YdbMergeSink implements ConnectorMergeSink {
             }
 
             String sql = remoteQueryModifier.apply(session, updateSql.toString());
+            List<Type> updateColumnTypes = updateColumnList.stream()
+                    .map(JdbcColumnHandle::getColumnType)
+                    .toList();
+            List<WriteFunction> updateColumnWriters = getColumnWriters(updateColumnTypes);
 
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-                for (Page page : pages) {
+                int batchSize = 0;
+                for (Page page : bufferedPages) {
+                    Block operationBlock = page.getBlock(columnCount);
+                    Block updateCaseBlock = page.getBlock(columnCount + 1);
+                    List<Block> rowIdFields = null;
                     for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                        if (TINYINT.getByte(operationBlock, pos) != UPDATE_OPERATION_NUMBER ||
+                                INTEGER.getInt(updateCaseBlock, pos) != caseNumber) {
+                            continue;
+                        }
+                        if (rowIdFields == null) {
+                            rowIdFields = RowBlock.getRowFieldsFromBlock(page.getBlock(columnCount + 2));
+                        }
                         for (int i = 0; i < updateColumnList.size(); i++) {
-                            Block block = page.getBlock(i);
-                            Type type = updateColumnList.get(i).getColumnType();
-                            WriteFunction writer = jdbcClient.toWriteMapping(session, type).getWriteFunction();
-                            setParameter(stmt, i + 1, block, pos, type, writer);
+                            setParameter(
+                                    stmt,
+                                    i + 1,
+                                    page.getBlock(updateChannels.get(i)),
+                                    pos,
+                                    updateColumnTypes.get(i),
+                                    updateColumnWriters.get(i));
                         }
 
                         int offset = updateColumnList.size();
                         for (int i = 0; i < primaryKeys.size(); i++) {
-                            Block block = page.getBlock(offset + i);
-                            Type type = primaryKeys.get(i).getColumnType();
-                            WriteFunction writer = jdbcClient.toWriteMapping(session, type).getWriteFunction();
-                            setParameter(stmt, offset + i + 1, block, pos, type, writer);
+                            setParameter(
+                                    stmt,
+                                    offset + i + 1,
+                                    rowIdFields.get(i),
+                                    pos,
+                                    primaryKeyTypes.get(i),
+                                    primaryKeyWriters.get(i));
                         }
-                        stmt.addBatch();
+                        batchSize = addToBatch(stmt, batchSize);
                     }
                 }
-                stmt.executeBatch();
+                executeRemainingBatch(stmt, batchSize);
             }
         }
     }
 
     private void executeInsertOperations(
             Connection connection,
-            List<Page> insertPages,
-            JdbcOutputTableHandle outputHandle
+            JdbcOutputTableHandle outputHandle,
+            int columnCount
     ) throws SQLException {
+        if (!containsOperation(columnCount, INSERT_OPERATION_NUMBER)) {
+            return;
+        }
+
         List<Type> columnTypes = outputHandle.getColumnTypes();
         List<WriteFunction> columnWriters = getColumnWriters(columnTypes);
         String insertSql = jdbcClient.buildInsertSql(outputHandle, columnWriters);
         insertSql = remoteQueryModifier.apply(session, insertSql);
 
         try (PreparedStatement insertStmt = connection.prepareStatement(insertSql)) {
-            int columnCount = outputHandle.getColumnNames().size();
-
-            for (Page page : insertPages) {
+            int batchSize = 0;
+            for (Page page : bufferedPages) {
+                Block operationBlock = page.getBlock(columnCount);
                 for (int pos = 0; pos < page.getPositionCount(); pos++) {
+                    if (TINYINT.getByte(operationBlock, pos) != INSERT_OPERATION_NUMBER) {
+                        continue;
+                    }
                     for (int channel = 0; channel < columnCount; channel++) {
                         setParameter(insertStmt, channel + 1, page.getBlock(channel), pos, columnTypes.get(channel), columnWriters.get(channel));
                     }
-                    insertStmt.addBatch();
+                    batchSize = addToBatch(insertStmt, batchSize);
                 }
             }
-            insertStmt.executeBatch();
+            executeRemainingBatch(insertStmt, batchSize);
         }
     }
 
-    private void separateMergeOperations(
-            Page page,
-            int columnCount,
-            List<Page> insertPages,
-            List<Page> deletePages,
-            Map<Integer, List<Page>> updatePagesByCase,
-            List<JdbcColumnHandle> columns
-    ) {
-        Block operationBlock = page.getBlock(columnCount);
-        Block updateCaseBlock = page.getBlock(columnCount + 1);
-
-        List<Integer> insertPositions = new ArrayList<>();
-        List<Integer> deletePositions = new ArrayList<>();
-        Map<Integer, List<Integer>> updatePositionsByCase = new HashMap<>();
-
-        for (int pos = 0; pos < page.getPositionCount(); pos++) {
-            int operation = TINYINT.getByte(operationBlock, pos);
-            switch (operation) {
-                case INSERT_OPERATION_NUMBER -> insertPositions.add(pos);
-                case DELETE_OPERATION_NUMBER -> deletePositions.add(pos);
-                case UPDATE_OPERATION_NUMBER -> {
-                    int caseNumber = INTEGER.getInt(updateCaseBlock, pos);
-                    updatePositionsByCase.computeIfAbsent(caseNumber, _ -> new ArrayList<>()).add(pos);
-                }
-                default -> throw new IllegalStateException();
-            }
-        }
-
-        if (!insertPositions.isEmpty()) {
-            int[] positions = insertPositions.stream().mapToInt(Integer::intValue).toArray();
-            Page insertData = page.getColumns(IntStream.range(0, columnCount).toArray())
-                    .getPositions(positions, 0, positions.length);
-            insertPages.add(insertData);
-        }
-
-        if (!deletePositions.isEmpty()) {
-            int[] positions = deletePositions.stream().mapToInt(Integer::intValue).toArray();
-            Block rowIdBlock = page.getBlock(columnCount + 2);
-            List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(rowIdBlock);
-            Block[] deleteBlocks = new Block[rowIdFields.size()];
-            for (int i = 0; i < rowIdFields.size(); i++) {
-                deleteBlocks[i] = rowIdFields.get(i).getPositions(positions, 0, positions.length);
-            }
-            deletePages.add(new Page(positions.length, deleteBlocks));
-        }
-
-        for (Map.Entry<Integer, List<Integer>> entry : updatePositionsByCase.entrySet()) {
-            int caseNumber = entry.getKey();
-            int[] positions = entry.getValue().stream().mapToInt(Integer::intValue).toArray();
-
-            Collection<ColumnHandle> updateColumns = mergeHandle.getUpdateCaseColumns().get(caseNumber);
-            if (updateColumns == null) continue;
-
-            Set<Integer> updateChannelsSet = updateColumns.stream()
-                    .map(JdbcColumnHandle.class::cast)
-                    .map(columns::indexOf)
-                    .collect(toImmutableSet());
-
-            List<Integer> updateChannelsList = new ArrayList<>();
-            for (int channel = 0; channel < columns.size(); channel++) {
-                if (updateChannelsSet.contains(channel)) {
-                    updateChannelsList.add(channel);
+    private void validateMergeOperations(int columnCount) {
+        for (Page page : bufferedPages) {
+            Block operationBlock = page.getBlock(columnCount);
+            Block updateCaseBlock = page.getBlock(columnCount + 1);
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                switch (TINYINT.getByte(operationBlock, position)) {
+                    case INSERT_OPERATION_NUMBER, DELETE_OPERATION_NUMBER -> {}
+                    case UPDATE_OPERATION_NUMBER -> {
+                        int caseNumber = INTEGER.getInt(updateCaseBlock, position);
+                        Collection<ColumnHandle> updateColumns = mergeHandle.getUpdateCaseColumns().get(caseNumber);
+                        if (updateColumns == null || updateColumns.isEmpty()) {
+                            throw new IllegalStateException("No columns for MERGE update case " + caseNumber);
+                        }
+                    }
+                    default -> throw new IllegalStateException();
                 }
             }
+        }
+    }
 
-            int[] updateChannels = updateChannelsList.stream().mapToInt(Integer::intValue).toArray();
-
-            Block rowIdBlock = page.getBlock(columnCount + 2);
-            List<Block> rowIdFields = RowBlock.getRowFieldsFromBlock(rowIdBlock);
-            Block[] updateBlocks = new Block[updateChannels.length + rowIdFields.size()];
-
-            int blockIdx = 0;
-            for (int channel : updateChannels) {
-                updateBlocks[blockIdx++] = page.getBlock(channel).getPositions(positions, 0, positions.length);
+    private boolean containsOperation(int columnCount, int expectedOperation) {
+        for (Page page : bufferedPages) {
+            Block operationBlock = page.getBlock(columnCount);
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                if (TINYINT.getByte(operationBlock, position) == expectedOperation) {
+                    return true;
+                }
             }
-            for (Block rowIdField : rowIdFields) {
-                updateBlocks[blockIdx++] = rowIdField.getPositions(positions, 0, positions.length);
-            }
+        }
+        return false;
+    }
 
-            updatePagesByCase.computeIfAbsent(caseNumber, _ -> new ArrayList<>())
-                    .add(new Page(positions.length, updateBlocks));
+    private boolean containsUpdateCase(int columnCount, int expectedCase) {
+        for (Page page : bufferedPages) {
+            Block operationBlock = page.getBlock(columnCount);
+            Block updateCaseBlock = page.getBlock(columnCount + 1);
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                if (TINYINT.getByte(operationBlock, position) == UPDATE_OPERATION_NUMBER &&
+                        INTEGER.getInt(updateCaseBlock, position) == expectedCase) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private int addToBatch(PreparedStatement statement, int batchSize) throws SQLException {
+        statement.addBatch();
+        batchSize++;
+        if (batchSize == maxBatchSize) {
+            statement.executeBatch();
+            return 0;
+        }
+        return batchSize;
+    }
+
+    private static void executeRemainingBatch(PreparedStatement statement, int batchSize) throws SQLException {
+        if (batchSize > 0) {
+            statement.executeBatch();
         }
     }
 
     private List<WriteFunction> getColumnWriters(List<Type> columnTypes) {
         return columnTypes.stream()
                 .map(type -> jdbcClient.toWriteMapping(session, type).getWriteFunction())
-                .collect(java.util.stream.Collectors.toList());
+                .toList();
     }
 
     private void setParameter(PreparedStatement stmt, int index, Block block, int position, Type type, WriteFunction writer) throws SQLException {

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
@@ -96,10 +96,12 @@ public class YdbMergeSink implements ConnectorMergeSink {
 
         for (int attempt = 0; attempt < maxAttempts; attempt++) {
             Connection connection = null;
+            boolean commitAttempted = false;
             boolean committed = false;
             try {
                 connection = openConnection();
                 executeMergeInTransaction(connection);
+                commitAttempted = true;
                 connection.commit();
                 committed = true;
                 connection.close();
@@ -129,6 +131,13 @@ public class YdbMergeSink implements ConnectorMergeSink {
 
                 if (committed) {
                     throw new TrinoException(JDBC_ERROR, "YDB MERGE committed, but closing its connection failed", e);
+                }
+
+                if (commitAttempted) {
+                    throw new TrinoException(
+                            JDBC_ERROR,
+                            "YDB MERGE commit outcome is unknown; operation was not retried to avoid duplicate writes",
+                            e);
                 }
 
                 if (!YdbRetryUtils.isRetryable(e) && !isRejectedDriverSessionAcquisition(e)) {

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbMergeSink.java
@@ -162,7 +162,8 @@ public class YdbMergeSink implements ConnectorMergeSink {
                 }
                 catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
-                    throw new TrinoException(JDBC_ERROR, ie);
+                    e.addSuppressed(ie);
+                    throw new TrinoException(JDBC_ERROR, "Interrupted while waiting to retry YDB MERGE", e);
                 }
             }
         }

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbPageSinkProvider.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbPageSinkProvider.java
@@ -19,7 +19,8 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 public record YdbPageSinkProvider(
         JdbcClient jdbcClient,
         RemoteQueryModifier remoteQueryModifier,
-        QueryBuilder queryBuilder
+        QueryBuilder queryBuilder,
+        YdbConfig config
 ) implements ConnectorPageSinkProvider {
     @Inject
     public YdbPageSinkProvider {
@@ -69,6 +70,7 @@ public record YdbPageSinkProvider(
                 jdbcClient,
                 pageSinkId,
                 remoteQueryModifier,
-                queryBuilder);
+                queryBuilder,
+                config.getMergeMaxBufferSize().toBytes());
     }
 }

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbRetryUtils.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbRetryUtils.java
@@ -1,56 +1,21 @@
 package tech.ydb.trino;
 
-import io.trino.spi.TrinoException;
 import tech.ydb.jdbc.exception.YdbStatusable;
 
-import java.sql.SQLException;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
-
 public final class YdbRetryUtils {
-    private static final int MAX_RETRIES = 10;
     private static final long BASE_DELAY_MS = 20;
     private static final long MAX_DELAY_MS = 1000;
 
     private YdbRetryUtils() {
     }
 
-    @FunctionalInterface
-    public interface SqlRunnable {
-        void run() throws SQLException;
-    }
-
-    public static void withRetry(SqlRunnable action) throws SQLException {
-        SQLException lastException = null;
-        for (int attempt = 0; attempt < MAX_RETRIES; attempt++) {
-            try {
-                action.run();
-                return;
-            }
-            catch (SQLException e) {
-                lastException = e;
-                if (!isRetryable(e)) {
-                    throw e;
-                }
-
-                long delay = calculateBackoff(attempt);
-                try {
-                    Thread.sleep(delay);
-                }
-                catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    throw new TrinoException(JDBC_ERROR, ie);
-                }
-            }
-        }
-        throw new TrinoException(JDBC_ERROR, lastException);
-    }
-
     public static boolean isRetryable(Throwable error) {
         Throwable current = error;
         while (current != null) {
             if (current instanceof YdbStatusable statusable) {
+                // false excludes statuses that are safe to retry only for idempotent operations.
                 return statusable.getStatus().getCode().isRetryable(false);
             }
             current = current.getCause();

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -1,0 +1,103 @@
+package tech.ydb.trino;
+
+import io.trino.spi.TrinoException;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+
+record YdbTablePath(String value)
+{
+    private static final int MAX_COMPONENT_LENGTH = 255;
+    private static final String DATA_SYSTEM_TABLE_SUFFIX = "$data";
+    private static final Pattern COMPONENT = Pattern.compile("[A-Za-z0-9._-]+");
+
+    static YdbTablePath fromUserInput(String value)
+    {
+        return parseUserInput(value);
+    }
+
+    static Optional<YdbTablePath> fromRemoteMetadata(String value)
+    {
+        return parse(value, false);
+    }
+
+    static boolean isDataSystemTableName(String value)
+    {
+        if (value == null || !value.endsWith(DATA_SYSTEM_TABLE_SUFFIX)) {
+            return false;
+        }
+        String tablePath = value.substring(0, value.length() - DATA_SYSTEM_TABLE_SUFFIX.length());
+        if (tablePath.isEmpty()) {
+            return false;
+        }
+        try {
+            fromUserInput(tablePath);
+            return true;
+        } catch (TrinoException e) {
+            return false;
+        }
+    }
+
+    String comparisonKey()
+    {
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    private static YdbTablePath parseUserInput(String value)
+    {
+        return parse(value, true).orElseThrow();
+    }
+
+    private static Optional<YdbTablePath> parse(String value, boolean userInput)
+    {
+        if (value == null) {
+            throw invalidPath(value, "path must not be null", userInput);
+        }
+
+        String[] components = value.split("/", -1);
+        if (!userInput) {
+            for (String component : components) {
+                if (component.startsWith(".")) {
+                    return Optional.empty();
+                }
+            }
+        }
+
+        for (String component : components) {
+            if (component.startsWith(".")) {
+                throw invalidPath(value, "components must not start with '.'", true);
+            }
+
+            String componentError = validateComponent(component);
+            if (componentError != null) {
+                throw invalidPath(value, componentError, userInput);
+            }
+        }
+        return Optional.of(new YdbTablePath(value));
+    }
+
+    private static String validateComponent(String component)
+    {
+        if (component.isEmpty()) {
+            return "components must not be empty";
+        }
+        if (component.length() > MAX_COMPONENT_LENGTH) {
+            return "components are too long; must be at most " + MAX_COMPONENT_LENGTH + " characters";
+        }
+        if (!COMPONENT.matcher(component).matches()) {
+            return "components may contain only letters, digits, '.', '_' and '-'";
+        }
+        return null;
+    }
+
+    private static TrinoException invalidPath(String value, String reason, boolean userInput)
+    {
+        return new TrinoException(
+                userInput ? INVALID_ARGUMENTS : JDBC_ERROR,
+                "Invalid YDB table path '" + value + "': " + reason);
+    }
+}

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTablePath.java
@@ -12,6 +12,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 record YdbTablePath(String value)
 {
     private static final int MAX_COMPONENT_LENGTH = 255;
+    private static final int MAX_PATH_DEPTH = 32;
     private static final String DATA_SYSTEM_TABLE_SUFFIX = "$data";
     private static final Pattern COMPONENT = Pattern.compile("[A-Za-z0-9._-]+");
 
@@ -65,6 +66,9 @@ record YdbTablePath(String value)
                     return Optional.empty();
                 }
             }
+        }
+        if (components.length > MAX_PATH_DEPTH) {
+            throw invalidPath(value, "paths are too deep; must contain at most " + MAX_PATH_DEPTH + " components", userInput);
         }
 
         for (String component : components) {

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTypeUtils.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTypeUtils.java
@@ -30,9 +30,9 @@ public final class YdbTypeUtils {
             case io.trino.spi.type.DoubleType _ ->
                     Optional.of(new JdbcTypeHandle(Types.DOUBLE, Optional.of("Double"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             case io.trino.spi.type.DateType _ ->
-                    Optional.of(new JdbcTypeHandle(Types.DATE, Optional.of("Date"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+                    Optional.of(new JdbcTypeHandle(Types.DATE, Optional.of("Date32"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             case io.trino.spi.type.TimestampType _ ->
-                    Optional.of(new JdbcTypeHandle(Types.TIMESTAMP, Optional.of("Timestamp"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+                    Optional.of(new JdbcTypeHandle(Types.TIMESTAMP, Optional.of("Timestamp64"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             case DecimalType decimalType ->
                     Optional.of(new JdbcTypeHandle(Types.DECIMAL, Optional.of("Decimal"), Optional.of(decimalType.getPrecision()), Optional.of(decimalType.getScale()), Optional.empty(), Optional.empty()));
             default ->

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/NonEphemeralPortsGenerator.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/NonEphemeralPortsGenerator.java
@@ -1,0 +1,70 @@
+package tech.ydb.trino;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.IntPredicate;
+
+import tech.ydb.test.integration.utils.PortsGenerator;
+
+import static java.util.Objects.requireNonNull;
+
+final class NonEphemeralPortsGenerator
+        extends PortsGenerator
+{
+    static final int MIN_PORT = 20_000;
+    static final int MAX_PORT = 29_999;
+
+    private static final int PORT_COUNT = MAX_PORT - MIN_PORT + 1;
+
+    private final IntPredicate availablePort;
+    private int nextPort;
+
+    NonEphemeralPortsGenerator()
+    {
+        this(ThreadLocalRandom.current().nextInt(MIN_PORT, MAX_PORT + 1));
+    }
+
+    NonEphemeralPortsGenerator(int startingPort)
+    {
+        this(startingPort, NonEphemeralPortsGenerator::canBind);
+    }
+
+    NonEphemeralPortsGenerator(int startingPort, IntPredicate availablePort)
+    {
+        if (startingPort < MIN_PORT || startingPort > MAX_PORT) {
+            throw new IllegalArgumentException("Starting port must be between %s and %s: %s"
+                    .formatted(MIN_PORT, MAX_PORT, startingPort));
+        }
+        this.nextPort = startingPort;
+        this.availablePort = requireNonNull(availablePort, "availablePort is null");
+    }
+
+    @Override
+    public synchronized int findAvailablePort()
+    {
+        for (int checked = 0; checked < PORT_COUNT; checked++) {
+            int candidate = nextPort;
+            nextPort = candidate == MAX_PORT ? MIN_PORT : candidate + 1;
+            if (availablePort.test(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("No wildcard TCP port is available in test range %s-%s; stop conflicting services"
+                .formatted(MIN_PORT, MAX_PORT));
+    }
+
+    private static boolean canBind(int port)
+    {
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(new InetSocketAddress((InetAddress) null, port), 1);
+            return true;
+        }
+        catch (IOException ignored) {
+            return false;
+        }
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestNonEphemeralPortsGenerator.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestNonEphemeralPortsGenerator.java
@@ -1,0 +1,83 @@
+package tech.ydb.trino;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestNonEphemeralPortsGenerator
+{
+    @Test
+    public void testSkipsOccupiedStartingPort()
+            throws IOException
+    {
+        try (ServerSocket occupied = reservePortInRange()) {
+            NonEphemeralPortsGenerator ports = new NonEphemeralPortsGenerator(occupied.getLocalPort());
+
+            int available = ports.findAvailablePort();
+
+            assertThat(available)
+                    .isBetween(NonEphemeralPortsGenerator.MIN_PORT, NonEphemeralPortsGenerator.MAX_PORT)
+                    .isNotEqualTo(occupied.getLocalPort());
+        }
+    }
+
+    @Test
+    public void testReturnsUniquePortsAcrossRangeBoundary()
+    {
+        NonEphemeralPortsGenerator ports = new NonEphemeralPortsGenerator(
+                NonEphemeralPortsGenerator.MAX_PORT,
+                ignored -> true);
+
+        List<Integer> allocated = List.of(
+                ports.findAvailablePort(),
+                ports.findAvailablePort(),
+                ports.findAvailablePort());
+
+        assertThat(allocated)
+                .containsExactly(
+                        NonEphemeralPortsGenerator.MAX_PORT,
+                        NonEphemeralPortsGenerator.MIN_PORT,
+                        NonEphemeralPortsGenerator.MIN_PORT + 1)
+                .doesNotHaveDuplicates()
+                .allSatisfy(port -> assertThat(port)
+                        .isBetween(NonEphemeralPortsGenerator.MIN_PORT, NonEphemeralPortsGenerator.MAX_PORT));
+    }
+
+    @Test
+    public void testReportsExhaustedRange()
+    {
+        NonEphemeralPortsGenerator ports = new NonEphemeralPortsGenerator(
+                NonEphemeralPortsGenerator.MIN_PORT,
+                ignored -> false);
+
+        assertThatThrownBy(ports::findAvailablePort)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("No wildcard TCP port is available in test range 20000-29999; stop conflicting services");
+    }
+
+    private static ServerSocket reservePortInRange()
+            throws IOException
+    {
+        for (int port = NonEphemeralPortsGenerator.MIN_PORT;
+                port <= NonEphemeralPortsGenerator.MAX_PORT;
+                port++) {
+            ServerSocket socket = new ServerSocket();
+            socket.setReuseAddress(false);
+            try {
+                socket.bind(new InetSocketAddress((InetAddress) null, port), 1);
+                return socket;
+            }
+            catch (IOException unavailable) {
+                socket.close();
+            }
+        }
+        throw new IOException("No port can be reserved in non-ephemeral test range");
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbCatalogFederation.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbCatalogFederation.java
@@ -1,0 +1,281 @@
+package tech.ydb.trino;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.testcontainers.DockerClientFactory;
+import tech.ydb.test.integration.YdbEnvironment;
+import tech.ydb.test.integration.YdbHelper;
+import tech.ydb.test.integration.docker.DockerHelperFactory;
+import tech.ydb.test.integration.docker.YdbDockerContainer;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Execution(SAME_THREAD)
+public class TestYdbCatalogFederation
+        extends AbstractTestQueryFramework
+{
+    private static final String PRIMARY_CATALOG = "ydb";
+    private static final String SECONDARY_CATALOG = "ydb_analytics";
+    private static final int YDB_START_ATTEMPTS = 3;
+
+    private YdbHelper primaryYdb;
+    private YdbHelper secondaryYdb;
+
+    private static final class LocalDockerEnvironment
+            extends YdbEnvironment
+    {
+        @Override
+        public String ydbEndpoint()
+        {
+            return null;
+        }
+
+        @Override
+        public String ydbDatabase()
+        {
+            return null;
+        }
+
+        @Override
+        public String dockerDatabase()
+        {
+            return "/local";
+        }
+
+        @Override
+        public boolean dockerReuse()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean useDockerIsolation()
+        {
+            return false;
+        }
+    }
+
+    private static YdbHelper startLocalYdb()
+    {
+        LocalDockerEnvironment environment = new LocalDockerEnvironment();
+        assumeFalse(environment.disableIntegrationTests(), "YDB integration tests are disabled");
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker-backed YDB is unavailable");
+
+        for (int attempt = 1; attempt <= YDB_START_ATTEMPTS; attempt++) {
+            YdbDockerContainer container = new YdbDockerContainer(environment, new NonEphemeralPortsGenerator());
+            try {
+                return new DockerHelperFactory(environment, container).createHelper();
+            }
+            catch (Exception | Error failure) {
+                closeSuppressing(failure, container);
+                if (attempt == YDB_START_ATTEMPTS || !isHostPortCollision(failure)) {
+                    throw failure;
+                }
+            }
+        }
+        throw new AssertionError("unreachable");
+    }
+
+    private static boolean isHostPortCollision(Throwable failure)
+    {
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message != null &&
+                    (message.contains("address already in use") || message.contains("port is already allocated"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        primaryYdb = startLocalYdb();
+        try {
+            secondaryYdb = startLocalYdb();
+            queryRunner = YdbQueryRunner.builder(primaryYdb)
+                    .setWorkerCount(1)
+                    .build();
+            queryRunner.createCatalog(
+                    SECONDARY_CATALOG,
+                    "ydb",
+                    YdbQueryRunner.connectorProperties(secondaryYdb));
+
+            closeAfterClass(primaryYdb);
+            closeAfterClass(secondaryYdb);
+            return queryRunner;
+        }
+        catch (Exception | Error failure) {
+            closeSuppressing(failure, queryRunner);
+            closeSuppressing(failure, secondaryYdb);
+            closeSuppressing(failure, primaryYdb);
+            throw failure;
+        }
+    }
+
+    private static void closeSuppressing(Throwable failure, AutoCloseable resource)
+    {
+        if (resource == null) {
+            return;
+        }
+        try {
+            resource.close();
+        }
+        catch (Throwable closeFailure) {
+            failure.addSuppressed(closeFailure);
+        }
+    }
+
+    private static String tableName(String catalog, String table)
+    {
+        return "%s.%s.%s".formatted(catalog, YdbQueryRunner.DEFAULT_SCHEMA, table);
+    }
+
+    private AutoCloseable dropTableOnClose(String table)
+    {
+        return () -> assertQuerySucceeds("DROP TABLE IF EXISTS " + table);
+    }
+
+    private void createMarkerTable(String table, String marker)
+    {
+        assertUpdate("CREATE TABLE " + table + " (id bigint NOT NULL, marker varchar)");
+        assertUpdate("INSERT INTO " + table + " (id, marker) VALUES (1, '" + marker + "')", 1);
+    }
+
+    @Test
+    public void testCatalogDiscoveryAndUseDefaultSchema()
+            throws Exception
+    {
+        assertThat(primaryYdb.database()).isEqualTo("/local");
+        assertThat(secondaryYdb.database()).isEqualTo("/local");
+        assertThat(primaryYdb.endpoint()).isNotEqualTo(secondaryYdb.endpoint());
+        assertThat(computeActual("SHOW CATALOGS").getOnlyColumnAsSet())
+                .contains(PRIMARY_CATALOG, SECONDARY_CATALOG);
+
+        assertQuerySucceeds("USE ydb.default");
+        assertQuerySucceeds("USE ydb_analytics.default");
+        assertQueryFails("USE ydb_analytics.missing", ".*Schema does not exist: ydb_analytics.missing.*");
+
+        String table = "federation_use_" + randomNameSuffix();
+        String analyticsTable = tableName(SECONDARY_CATALOG, table);
+        try (AutoCloseable ignored = dropTableOnClose(analyticsTable)) {
+            createMarkerTable(analyticsTable, "analytics");
+
+            Session analyticsSession = Session.builder(getSession())
+                    .setCatalog(SECONDARY_CATALOG)
+                    .setSchema(YdbQueryRunner.DEFAULT_SCHEMA)
+                    .build();
+            assertQuery(analyticsSession, "SELECT marker FROM " + table, "VALUES 'analytics'");
+        }
+    }
+
+    @Test
+    public void testSameNamedTablesAreIsolated()
+            throws Exception
+    {
+        String table = "federation_isolation_" + randomNameSuffix();
+        String primaryTable = tableName(PRIMARY_CATALOG, table);
+        String analyticsTable = tableName(SECONDARY_CATALOG, table);
+        try (AutoCloseable ignoredPrimary = dropTableOnClose(primaryTable);
+                AutoCloseable ignoredAnalytics = dropTableOnClose(analyticsTable)) {
+            createMarkerTable(primaryTable, "primary");
+            createMarkerTable(analyticsTable, "analytics");
+
+            assertQuery("SELECT id, marker FROM " + primaryTable, "VALUES (CAST(1 AS BIGINT), 'primary')");
+            assertQuery("SELECT id, marker FROM " + analyticsTable, "VALUES (CAST(1 AS BIGINT), 'analytics')");
+        }
+    }
+
+    @Test
+    public void testCrossCatalogReadJoin()
+            throws Exception
+    {
+        String primaryTable = tableName(PRIMARY_CATALOG, "federation_primary_" + randomNameSuffix());
+        String analyticsTable = tableName(SECONDARY_CATALOG, "federation_analytics_" + randomNameSuffix());
+        try (AutoCloseable ignoredPrimary = dropTableOnClose(primaryTable);
+                AutoCloseable ignoredAnalytics = dropTableOnClose(analyticsTable)) {
+            createMarkerTable(primaryTable, "primary");
+            createMarkerTable(analyticsTable, "analytics");
+
+            assertQuery(
+                    "SELECT p.id, p.marker, a.marker " +
+                            "FROM " + primaryTable + " p " +
+                            "JOIN " + analyticsTable + " a ON p.id = a.id",
+                    "VALUES (CAST(1 AS BIGINT), 'primary', 'analytics')");
+        }
+    }
+
+    @Test
+    public void testAutocommitReadManyWriteOne()
+            throws Exception
+    {
+        String primarySource = tableName(PRIMARY_CATALOG, "federation_primary_" + randomNameSuffix());
+        String analyticsSource = tableName(SECONDARY_CATALOG, "federation_analytics_" + randomNameSuffix());
+        String primaryTarget = tableName(PRIMARY_CATALOG, "federation_output_" + randomNameSuffix());
+        try (AutoCloseable ignoredPrimarySource = dropTableOnClose(primarySource);
+                AutoCloseable ignoredAnalyticsSource = dropTableOnClose(analyticsSource);
+                AutoCloseable ignoredPrimaryTarget = dropTableOnClose(primaryTarget)) {
+            createMarkerTable(primarySource, "primary");
+            createMarkerTable(analyticsSource, "analytics");
+            assertUpdate("CREATE TABLE " + primaryTarget + " (id bigint NOT NULL, marker varchar)");
+
+            assertUpdate(
+                    "INSERT INTO " + primaryTarget + " (id, marker) " +
+                            "SELECT p.id, p.marker || ':' || a.marker " +
+                            "FROM " + primarySource + " p " +
+                            "JOIN " + analyticsSource + " a ON p.id = a.id",
+                    1);
+            assertQuery("SELECT id, marker FROM " + primaryTarget, "VALUES (CAST(1 AS BIGINT), 'primary:analytics')");
+        }
+    }
+
+    @Test
+    public void testExplicitTransactionReadsAndRejectsYdbWrite()
+            throws Exception
+    {
+        String primarySource = tableName(PRIMARY_CATALOG, "federation_primary_" + randomNameSuffix());
+        String analyticsSource = tableName(SECONDARY_CATALOG, "federation_analytics_" + randomNameSuffix());
+        String analyticsTarget = tableName(SECONDARY_CATALOG, "federation_output_" + randomNameSuffix());
+        try (AutoCloseable ignoredPrimarySource = dropTableOnClose(primarySource);
+                AutoCloseable ignoredAnalyticsSource = dropTableOnClose(analyticsSource);
+                AutoCloseable ignoredAnalyticsTarget = dropTableOnClose(analyticsTarget)) {
+            createMarkerTable(primarySource, "primary");
+            createMarkerTable(analyticsSource, "analytics");
+            assertUpdate("CREATE TABLE " + analyticsTarget + " (id bigint NOT NULL, marker varchar)");
+
+            String crossCatalogJoin = "SELECT p.id, p.marker, a.marker " +
+                    "FROM " + primarySource + " p " +
+                    "JOIN " + analyticsSource + " a ON p.id = a.id";
+            Session transactionBase = Session.builder(getSession())
+                    .setCatalog(PRIMARY_CATALOG)
+                    .setSchema(YdbQueryRunner.DEFAULT_SCHEMA)
+                    .build();
+
+            assertThatThrownBy(() -> newTransaction().execute(transactionBase, transactionSession -> {
+                assertQuery(
+                        transactionSession,
+                        crossCatalogJoin,
+                        "VALUES (CAST(1 AS BIGINT), 'primary', 'analytics')");
+                assertUpdate(
+                        transactionSession,
+                        "INSERT INTO " + analyticsTarget + " (id, marker) VALUES (2, 'must-not-commit')",
+                        1);
+            }))
+                    .hasMessageMatching("Catalog only supports writes using autocommit: ydb_analytics");
+
+            assertQuery("SELECT count(*) FROM " + analyticsTarget, "VALUES CAST(0 AS BIGINT)");
+        }
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbColumnMappings.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbColumnMappings.java
@@ -1,0 +1,136 @@
+package tech.ydb.trino;
+
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.predicate.Domain;
+import io.trino.testing.TestingConnectorSession;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestYdbColumnMappings
+{
+    private static final ConnectorSession SESSION = TestingConnectorSession.builder()
+            .setPropertyMetadata(new JdbcMetadataSessionProperties(
+                    new JdbcMetadataConfig(), Optional.empty()).getSessionProperties())
+            .build();
+
+    @Test
+    void testDatePredicateIsPushedWithinYdbRange()
+    {
+        Domain supportedDate = Domain.multipleValues(DATE, List.of(
+                LocalDate.of(1970, 1, 1).toEpochDay(),
+                LocalDate.of(1995, 9, 16).toEpochDay(),
+                LocalDate.of(2105, 12, 31).toEpochDay()));
+
+        DomainPushdownResult result = YdbClient.dateColumnMapping("Date")
+                .getPredicatePushdownController()
+                .apply(SESSION, supportedDate);
+
+        assertThat(result.getPushedDown()).isEqualTo(supportedDate);
+        assertThat(result.getRemainingFilter()).isEqualTo(Domain.all(DATE));
+    }
+
+    @Test
+    void testDatePredicateRemainsInTrino()
+    {
+        Domain negativeDate = Domain.singleValue(DATE, LocalDate.of(-1996, 9, 14).toEpochDay());
+
+        DomainPushdownResult result = YdbClient.dateColumnMapping("Date")
+                .getPredicatePushdownController()
+                .apply(SESSION, negativeDate);
+
+        assertThat(result.getPushedDown()).isEqualTo(Domain.all(DATE));
+        assertThat(result.getRemainingFilter()).isEqualTo(negativeDate);
+    }
+
+    @Test
+    void testDatePredicateAboveYdbRangeRemainsInTrino()
+    {
+        Domain unsupportedDate = Domain.singleValue(DATE, LocalDate.of(2106, 1, 1).toEpochDay());
+
+        DomainPushdownResult result = YdbClient.dateColumnMapping("Date")
+                .getPredicatePushdownController()
+                .apply(SESSION, unsupportedDate);
+
+        assertThat(result.getPushedDown()).isEqualTo(Domain.all(DATE));
+        assertThat(result.getRemainingFilter()).isEqualTo(unsupportedDate);
+    }
+
+    @Test
+    void testDate32PredicateIsPushedBeforeUnixEpoch()
+    {
+        Domain signedDate = Domain.multipleValues(DATE, List.of(
+                LocalDate.of(1, 1, 1).toEpochDay(),
+                LocalDate.of(1969, 12, 31).toEpochDay()));
+
+        DomainPushdownResult result = YdbClient.dateColumnMapping("Date32")
+                .getPredicatePushdownController()
+                .apply(SESSION, signedDate);
+
+        assertThat(result.getPushedDown()).isEqualTo(signedDate);
+        assertThat(result.getRemainingFilter()).isEqualTo(Domain.all(DATE));
+    }
+
+    @Test
+    void testDate32PredicateOutsideYdbRangeRemainsInTrino()
+    {
+        Domain unsupportedDate = Domain.singleValue(DATE, LocalDate.of(-144169, 12, 31).toEpochDay());
+
+        DomainPushdownResult result = YdbClient.dateColumnMapping("Date32")
+                .getPredicatePushdownController()
+                .apply(SESSION, unsupportedDate);
+
+        assertThat(result.getPushedDown()).isEqualTo(Domain.all(DATE));
+        assertThat(result.getRemainingFilter()).isEqualTo(unsupportedDate);
+    }
+
+    @Test
+    void testTemporalMappingsRespectPhysicalPrecision()
+    {
+        assertThat(YdbClient.timestampColumnMapping("Datetime").getType()).isEqualTo(createTimestampType(0));
+        assertThat(YdbClient.timestampColumnMapping("Datetime64").getType()).isEqualTo(createTimestampType(0));
+        assertThat(YdbClient.timestampColumnMapping("Timestamp").getType()).isEqualTo(TIMESTAMP_MICROS);
+        assertThat(YdbClient.timestampColumnMapping("Timestamp64").getType()).isEqualTo(TIMESTAMP_MICROS);
+    }
+
+    @Test
+    void testTimestamp64PredicateRespectsPinnedDriverUpperBound()
+    {
+        long lastDriverSupportedEpochMicro = 4_611_669_811_199_999_998L;
+        Domain supportedTimestamp = Domain.singleValue(TIMESTAMP_MICROS, lastDriverSupportedEpochMicro);
+        Domain rejectedByDriver = Domain.singleValue(TIMESTAMP_MICROS, lastDriverSupportedEpochMicro + 1);
+
+        DomainPushdownResult supportedResult = YdbClient.timestampColumnMapping("Timestamp64")
+                .getPredicatePushdownController()
+                .apply(SESSION, supportedTimestamp);
+        DomainPushdownResult rejectedResult = YdbClient.timestampColumnMapping("Timestamp64")
+                .getPredicatePushdownController()
+                .apply(SESSION, rejectedByDriver);
+
+        assertThat(supportedResult.getPushedDown()).isEqualTo(supportedTimestamp);
+        assertThat(supportedResult.getRemainingFilter()).isEqualTo(Domain.all(TIMESTAMP_MICROS));
+        assertThat(rejectedResult.getPushedDown()).isEqualTo(Domain.all(TIMESTAMP_MICROS));
+        assertThat(rejectedResult.getRemainingFilter()).isEqualTo(rejectedByDriver);
+    }
+
+    @Test
+    void testDefaultTemporalTypeHandlesUseWideYdbTypes()
+    {
+        JdbcTypeHandle date = YdbTypeUtils.toTypeHandle(DATE).orElseThrow();
+        JdbcTypeHandle timestamp = YdbTypeUtils.toTypeHandle(TIMESTAMP_MICROS).orElseThrow();
+
+        assertThat(date.jdbcTypeName()).contains("Date32");
+        assertThat(timestamp.jdbcTypeName()).contains("Timestamp64");
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -204,6 +204,35 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     }
 
     @Test
+    public void testTransactionalInsertStagingDoesNotPartiallyMutateTarget() throws Exception {
+        String table = "transactional_insert_" + uniqueSuffix();
+        Session transactionalInsert = Session.builder(getSession())
+                .setCatalogSessionProperty("ydb", "non_transactional_insert", "false")
+                .setCatalogSessionProperty("ydb", "write_batch_size", "1")
+                .setCatalogSessionProperty("ydb", "write_parallelism", "1")
+                .build();
+
+        createRawTable(table);
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" VALUES (1)", 1);
+
+            assertQueryFails(
+                    transactionalInsert,
+                    "INSERT INTO \"" + table + "\" VALUES (2), (1)",
+                    "(?is).*constraint violation.*");
+            assertQuery("SELECT id FROM \"" + table + "\"", "VALUES CAST(1 AS BIGINT)");
+
+            assertUpdate(transactionalInsert, "INSERT INTO \"" + table + "\" VALUES (2), (3)", 2);
+            assertQuery(
+                    "SELECT id FROM \"" + table + "\" ORDER BY id",
+                    "VALUES CAST(1 AS BIGINT), CAST(2 AS BIGINT), CAST(3 AS BIGINT)");
+        }
+        finally {
+            dropRawTable(table);
+        }
+    }
+
+    @Test
     public void testMergeUsesCompleteCompositePrimaryKeyWithNonKeyFirstColumn() throws Exception {
         String table = "merge_composite_key_" + uniqueSuffix();
 

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -3,7 +3,11 @@ package tech.ydb.trino;
 import io.trino.Session;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
-import io.trino.testing.*;
+import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.TestTable;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -12,9 +16,12 @@ import tech.ydb.test.junit5.YdbHelperExtension;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
@@ -219,7 +226,7 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
             assertQueryFails(
                     transactionalInsert,
                     "INSERT INTO \"" + table + "\" VALUES (2), (1)",
-                    "(?is).*constraint violation.*");
+                    "(?is).*PRECONDITION_FAILED.*conflict with existing key.*");
             assertQuery("SELECT id FROM \"" + table + "\"", "VALUES CAST(1 AS BIGINT)");
 
             assertUpdate(transactionalInsert, "INSERT INTO \"" + table + "\" VALUES (2), (3)", 2);
@@ -310,6 +317,63 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         }
     }
 
+    @Test
+    public void testExtendedTemporalTypesPreserveRangeAndPrecision() throws Exception {
+        String table = "extended_temporal_" + uniqueSuffix();
+        executeRaw("CREATE TABLE `" + table + "` (" +
+                "id Int64 NOT NULL, wide_date Date32, wide_datetime Datetime64, wide_timestamp Timestamp64, " +
+                "legacy_date Date, legacy_datetime Datetime, legacy_timestamp Timestamp, PRIMARY KEY (id))");
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" VALUES " +
+                    "(1, DATE '1969-12-31', TIMESTAMP '1969-12-31 23:59:58', " +
+                    "TIMESTAMP '1969-12-31 23:59:58.123456', NULL, NULL, NULL), " +
+                    "(2, DATE '2001-02-03', TIMESTAMP '2001-02-03 04:05:06', " +
+                    "TIMESTAMP '2001-02-03 04:05:06.654321', DATE '2001-02-03', " +
+                    "TIMESTAMP '2001-02-03 04:05:06', TIMESTAMP '2001-02-03 04:05:06.654321'), " +
+                    "(3, NULL, NULL, NULL, NULL, NULL, NULL)", 3);
+
+            assertQuery(
+                    "SELECT * FROM \"" + table + "\" ORDER BY id",
+                    "VALUES " +
+                            "(CAST(1 AS BIGINT), DATE '1969-12-31', CAST(TIMESTAMP '1969-12-31 23:59:58' AS TIMESTAMP(0)), " +
+                            "TIMESTAMP '1969-12-31 23:59:58.123456', NULL, NULL, NULL), " +
+                            "(CAST(2 AS BIGINT), DATE '2001-02-03', CAST(TIMESTAMP '2001-02-03 04:05:06' AS TIMESTAMP(0)), " +
+                            "TIMESTAMP '2001-02-03 04:05:06.654321', DATE '2001-02-03', " +
+                            "CAST(TIMESTAMP '2001-02-03 04:05:06' AS TIMESTAMP(0)), " +
+                            "TIMESTAMP '2001-02-03 04:05:06.654321'), " +
+                            "(CAST(3 AS BIGINT), NULL, NULL, NULL, NULL, NULL, NULL)");
+            assertQuery(
+                    "SELECT id FROM \"" + table + "\" " +
+                            "WHERE wide_date = DATE '1969-12-31' " +
+                            "AND wide_datetime = TIMESTAMP '1969-12-31 23:59:58' " +
+                            "AND wide_timestamp = TIMESTAMP '1969-12-31 23:59:58.123456'",
+                    "VALUES CAST(1 AS BIGINT)");
+        }
+        finally {
+            dropRawTable(table);
+        }
+    }
+
+    @Test
+    public void testCreatedTemporalColumnsUseWideYdbTypes() throws Exception {
+        String table = "created_temporal_" + uniqueSuffix();
+        try {
+            assertUpdate("CREATE TABLE \"" + table + "\" AS SELECT " +
+                    "DATE '1969-12-31' AS wide_date, " +
+                    "TIMESTAMP '1969-12-31 23:59:58.123456' AS wide_timestamp", 1);
+
+            assertThat(rawColumnTypes(table))
+                    .containsEntry("wide_date", "Date32")
+                    .containsEntry("wide_timestamp", "Timestamp64");
+            assertQuery(
+                    "SELECT wide_date, wide_timestamp FROM \"" + table + "\"",
+                    "VALUES (DATE '1969-12-31', TIMESTAMP '1969-12-31 23:59:58.123456')");
+        }
+        finally {
+            assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"");
+        }
+    }
+
     private static String uniqueSuffix() {
         return UUID.randomUUID().toString().replace("-", "");
     }
@@ -357,6 +421,28 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         }
     }
 
+    private static void executeRaw(String sql) {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to execute YDB test DDL", e);
+        }
+    }
+
+    private static Map<String, String> rawColumnTypes(String table) throws SQLException {
+        Map<String, String> types = new LinkedHashMap<>();
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                ResultSet columns = connection.getMetaData().getColumns(connection.getCatalog(), null, null, null)) {
+            while (columns.next()) {
+                if (columns.getString("TABLE_NAME").equals(table)) {
+                    types.put(columns.getString("COLUMN_NAME"), columns.getString("TYPE_NAME"));
+                }
+            }
+        }
+        return types;
+    }
+
     @Override
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior) {
         return switch (connectorBehavior) {
@@ -390,38 +476,24 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
 
     @Test
     @Override
-    public void testInsertNegativeDate() {
-        // YDB не поддерживает, negative daysSinceEpoch
-    }
-
-    @Test
-    @Override
-    public void testDateYearOfEraPredicate() {
-        // YDB не поддерживает, negative daysSinceEpoch
-    }
-
-    @Test
-    @Override
-    public void testCreateTableAsSelectNegativeDate() {
-        // YDB не поддерживает, negative daysSinceEpoch
-    }
-
-    @Test
-    @Override
     public void testCharVarcharComparison() {
-        // CHAR хранится как String без паддинга
+        // YDB has no fixed-width string primitive. Mapping CHAR to Text loses its width in JDBC metadata
+        // and violates Trino padding/coercion semantics: https://ydb.tech/docs/en/yql/reference/types/primitive
+        assertThatThrownBy(super::testCharVarcharComparison)
+                .hasMessage("Unsupported column type: char(3)");
     }
 
-    @Test
     @Override
-    public void testVarcharCastToDateInPredicate() {
-        // YDB не поддерживает такой pushdown/cast
-    }
-
-    @Test
-    @Override
-    public void testInsertForDefaultColumn() {
-        // Requires createTableWithDefaultColumns() which is connector-specific and not supported yet
+    protected TestTable createTableWithDefaultColumns() {
+        return new TestTable(
+                TestYdbConnectorTest::executeRaw,
+                "test_insert_default_",
+                "(col_required Int64 NOT NULL, " +
+                        "col_nullable Int64, " +
+                        "col_default Int64 DEFAULT 43, " +
+                        "col_nonnull_default Int64 NOT NULL DEFAULT 42, " +
+                        "col_required2 Int64 NOT NULL, " +
+                        "PRIMARY KEY (col_required))");
     }
 
     @Override
@@ -441,7 +513,9 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
 
     @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(BaseConnectorTest.DataMappingTestSetup dataMappingTestSetup) {
-        if (dataMappingTestSetup.getTrinoTypeName().equals("date")) {
+        if (dataMappingTestSetup.getTrinoTypeName().equals("char(3)")) {
+            return Optional.of(dataMappingTestSetup.asUnsupported());
+        } else if (dataMappingTestSetup.getTrinoTypeName().equals("date")) {
             return Optional.of(new DataMappingTestSetup(
                     dataMappingTestSetup.getTrinoTypeName(),
                     "DATE '2006-06-06'",
@@ -450,6 +524,14 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         } else if (dataMappingTestSetup.getTrinoTypeName().startsWith("time") || dataMappingTestSetup.getTrinoTypeName().equals("varbinary")) {
             // Нет time и varbinary в YQL
             return Optional.empty();
+        }
+        return Optional.of(dataMappingTestSetup);
+    }
+
+    @Override
+    protected Optional<DataMappingTestSetup> filterCaseSensitiveDataMappingTestData(DataMappingTestSetup dataMappingTestSetup) {
+        if (dataMappingTestSetup.getTrinoTypeName().equals("char(1)")) {
+            return Optional.of(dataMappingTestSetup.asUnsupported());
         }
         return Optional.of(dataMappingTestSetup);
     }

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -1,17 +1,26 @@
 package tech.ydb.trino;
 
+import io.trino.Session;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.testing.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import tech.ydb.scheme.SchemeClient;
 import tech.ydb.test.junit5.YdbHelperExtension;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestYdbConnectorTest extends BaseConnectorTest {
 
@@ -23,6 +32,212 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         return YdbQueryRunner.builder(ydb)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
+    }
+
+    @Test
+    public void testDefaultSchemaContract() {
+        assertThat(computeActual("SHOW SCHEMAS FROM ydb").getOnlyColumnAsSet())
+                .contains("default")
+                .doesNotContain("ydb");
+        assertThat(computeActual("SHOW TABLES FROM ydb.default").getOnlyColumnAsSet())
+                .contains("orders");
+        assertQueryFails("SELECT * FROM ydb.missing.orders", ".*Schema 'missing' does not exist");
+    }
+
+    @Test
+    public void testNestedTablePath() throws Exception {
+        String namespace = "namespace_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+
+        createDirectory(directory);
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
+            assertQuerySucceeds("CREATE TABLE \"" + table + "\" (id bigint NOT NULL)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(table);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + table + "\"");
+            assertThat(computeScalar("SHOW CREATE TABLE \"" + table + "\"").toString()).contains(table);
+        }
+    }
+
+    @Test
+    public void testNestedTablePathLongerThanSingleComponentLimit() throws Exception {
+        String suffix = uniqueSuffix();
+        String parent = "long_" + "a".repeat(130) + suffix;
+        String directory = parent + "/branch_" + "b".repeat(90);
+        String sourceTable = directory + "/source_" + suffix;
+        String renamedTable = directory + "/renamed_" + suffix;
+
+        assertThat(sourceTable.length()).isGreaterThan(255);
+        createDirectory(directory);
+        try (AutoCloseable ignoredParent = () -> removeDirectory(parent);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredSourceTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + sourceTable + "\"");
+                AutoCloseable ignoredRenamedTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + renamedTable + "\"")) {
+            assertQuerySucceeds("CREATE TABLE \"" + sourceTable + "\" (id bigint NOT NULL)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(sourceTable);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + sourceTable + "\"");
+
+            assertQuerySucceeds("ALTER TABLE \"" + sourceTable + "\" RENAME TO \"" + renamedTable + "\"");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                    .contains(renamedTable)
+                    .doesNotContain(sourceTable);
+            assertQueryReturnsEmptyResult("SELECT id FROM \"" + renamedTable + "\"");
+        }
+    }
+
+    @Test
+    public void testDefaultSchemaRelationComments() throws Exception {
+        String namespace = "comments_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+
+        createDirectory(directory);
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
+            assertQuerySucceeds("CREATE TABLE \"" + table + "\" (id bigint NOT NULL)");
+
+            assertThat(query(
+                    "SELECT schema_name, table_name, comment " +
+                            "FROM system.metadata.table_comments " +
+                            "WHERE catalog_name = 'ydb' AND schema_name = 'default'"))
+                    .skippingTypesCheck()
+                    .containsAll("VALUES ('default', '" + table + "', null)");
+            assertQueryReturnsEmptyResult(
+                    "SELECT table_name FROM system.metadata.table_comments " +
+                            "WHERE catalog_name = 'ydb' AND schema_name = 'missing'");
+        }
+    }
+
+    @Test
+    public void testDefaultSchemaBulkColumns() throws Exception {
+        String namespace = "columns_" + uniqueSuffix();
+        String directory = namespace + "/eu";
+        String table = directory + "/orders";
+        Session bulkSession = Session.builder(getSession())
+                .setCatalogSessionProperty("ydb", "bulk_list_columns", "true")
+                .build();
+
+        createDirectory(directory);
+        try (AutoCloseable ignoredNamespace = () -> removeDirectory(namespace);
+                AutoCloseable ignoredDirectory = () -> removeDirectory(directory);
+                AutoCloseable ignoredTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + table + "\"")) {
+            createRawMetadataTable(table);
+
+            assertQuery(
+                    bulkSession,
+                    "SELECT column_name, data_type, is_nullable " +
+                            "FROM information_schema.columns " +
+                            "WHERE table_schema = 'default' AND table_name = '" + table + "' " +
+                            "ORDER BY ordinal_position",
+                    "VALUES ('id', 'bigint', 'NO'), ('note', 'varchar', 'YES')");
+            assertQueryReturnsEmptyResult(
+                    bulkSession,
+                    "SELECT column_name FROM information_schema.columns " +
+                            "WHERE table_schema = 'missing' AND table_name = '" + table + "'");
+        }
+    }
+
+    @Test
+    public void testInvalidTablePaths() {
+        for (String table : List.of("/orders", "a//orders", "a/../orders", ".sys/orders")) {
+            assertQueryFails("SELECT * FROM ydb.default.\"" + table + "\"", ".*Invalid YDB table path.*");
+        }
+    }
+
+    @Test
+    public void testCaseOnlyTablePathAmbiguity() throws Exception {
+        String suffix = uniqueSuffix();
+        String firstDirectory = "Case_" + suffix;
+        String secondDirectory = "case_" + suffix;
+        String firstTable = firstDirectory + "/Orders";
+        String secondTable = secondDirectory + "/orders";
+
+        createDirectory(firstDirectory);
+        try (AutoCloseable ignoredFirstDirectory = () -> removeDirectory(firstDirectory)) {
+            createDirectory(secondDirectory);
+            try (AutoCloseable ignoredSecondDirectory = () -> removeDirectory(secondDirectory)) {
+                createRawTable(firstTable);
+                try (AutoCloseable ignoredFirstTable = () -> dropRawTable(firstTable)) {
+                    createRawTable(secondTable);
+                    try (AutoCloseable ignoredSecondTable = () -> dropRawTable(secondTable)) {
+                        assertQueryFails(
+                                "SELECT * FROM \"" + secondTable + "\"",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                        Session bulkSession = Session.builder(getSession())
+                                .setCatalogSessionProperty("ydb", "bulk_list_columns", "true")
+                                .build();
+                        assertQueryFails(
+                                bulkSession,
+                                "SELECT table_name FROM information_schema.columns WHERE table_schema = 'default'",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                        assertQueryFails(
+                                "SELECT table_name FROM system.metadata.table_comments " +
+                                        "WHERE catalog_name = 'ydb' AND schema_name = 'default'",
+                                ".*(?s)Ambiguous.*" + firstTable + ".*" + secondTable + ".*");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUniqueCaseTableWriteLifecycle() throws Exception {
+        String suffix = uniqueSuffix();
+        String remoteTable = "MixedCase_" + suffix;
+        String logicalTable = remoteTable.toLowerCase(java.util.Locale.ROOT);
+        String renamedTable = "renamed_" + suffix;
+
+        try (AutoCloseable ignoredOriginalTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + logicalTable + "\"");
+                AutoCloseable ignoredRenamedTable = () -> assertQuerySucceeds("DROP TABLE IF EXISTS \"" + renamedTable + "\"")) {
+            createRawTable(remoteTable);
+
+            assertUpdate("INSERT INTO \"" + logicalTable + "\" VALUES (1)", 1);
+            assertQuerySucceeds("ALTER TABLE \"" + logicalTable + "\" RENAME TO \"" + renamedTable + "\"");
+
+            assertQuery("SELECT id FROM \"" + renamedTable + "\"", "VALUES CAST(1 AS BIGINT)");
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(renamedTable);
+        }
+    }
+
+    private static String uniqueSuffix() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static void createDirectory(String relativePath) {
+        try (SchemeClient client = SchemeClient.newClient(ydb.createTransport()).build()) {
+            client.makeDirectories(ydb.database() + "/" + relativePath).join().expectSuccess();
+        }
+    }
+
+    private static void removeDirectory(String relativePath) {
+        try (SchemeClient client = SchemeClient.newClient(ydb.createTransport()).build()) {
+            client.removeDirectory(ydb.database() + "/" + relativePath).join().expectSuccess();
+        }
+    }
+
+    private static void createRawTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` (id Int64 NOT NULL, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void createRawMetadataTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` " +
+                    "(id Int64 NOT NULL, note Utf8, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void dropRawTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE `" + remoteTable + "`");
+        }
     }
 
     @Override
@@ -145,6 +360,38 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
     @Override
     protected OptionalInt maxColumnNameLength() {
         return OptionalInt.of(255);
+    }
+
+    @Test
+    @Override
+    public void testRenameTableToLongTableName() {
+        skipTestUnless(hasBehavior(TestingConnectorBehavior.SUPPORTS_RENAME_TABLE));
+
+        String sourceTableName = "test_rename_source_" + uniqueSuffix();
+        String baseTableName = "test_rename_target_" + uniqueSuffix();
+        int maxLength = maxTableRenameLength().orElseThrow();
+        String validTargetTableName = baseTableName + "z".repeat(maxLength - baseTableName.length());
+        String invalidTargetTableName = validTargetTableName + "z";
+
+        try {
+            assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
+            assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + validTargetTableName);
+            assertThat(getQueryRunner().tableExists(getSession(), validTargetTableName)).isTrue();
+            assertQuery("SELECT x FROM " + validTargetTableName, "VALUES 123");
+            assertUpdate("DROP TABLE " + validTargetTableName);
+
+            assertUpdate("CREATE TABLE " + sourceTableName + " AS SELECT 123 x", 1);
+            assertThatThrownBy(() -> assertUpdate("ALTER TABLE " + sourceTableName + " RENAME TO " + invalidTargetTableName))
+                    .satisfies(this::verifyTableNameLengthFailurePermissible);
+            assertThat(getQueryRunner().tableExists(getSession(), sourceTableName)).isTrue();
+            assertQuery("SELECT x FROM " + sourceTableName, "VALUES 123");
+
+            // Trino 479 expects tableExists(invalidTarget) to be false, but this lookup returns INVALID_ARGUMENTS.
+            assertQueryFails("SELECT x FROM " + invalidTargetTableName, ".*Invalid YDB table path.*too long.*");
+        } finally {
+            assertQuerySucceeds("DROP TABLE IF EXISTS " + validTargetTableName);
+            assertQuerySucceeds("DROP TABLE IF EXISTS " + sourceTableName);
+        }
     }
 
     @Override

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
 
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -202,6 +203,84 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
         }
     }
 
+    @Test
+    public void testMergeUsesCompleteCompositePrimaryKeyWithNonKeyFirstColumn() throws Exception {
+        String table = "merge_composite_key_" + uniqueSuffix();
+
+        createRawCompositePrimaryKeyTable(table);
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
+                    "('shared', 1, 10, 'old'), " +
+                    "('shared', 1, 20, 'sibling'), " +
+                    "('shared', 2, 10, 'cross-sibling'), " +
+                    "('shared', 2, 20, 'remove'), " +
+                    "('keep', 3, 30, 'stable')", 5);
+
+            assertUpdate("""
+                    MERGE INTO "%s" target
+                    USING (VALUES
+                        (BIGINT '1', BIGINT '10', 'updated', 'update'),
+                        (BIGINT '2', BIGINT '20', 'unused', 'delete'),
+                        (BIGINT '4', BIGINT '40', 'inserted', 'insert'))
+                        AS source(account, region, note, operation)
+                    ON target.account = source.account AND target.region = source.region
+                    WHEN MATCHED AND source.operation = 'delete' THEN DELETE
+                    WHEN MATCHED THEN UPDATE SET bucket = 'shared', note = source.note
+                    WHEN NOT MATCHED THEN INSERT (bucket, account, region, note)
+                        VALUES ('shared', source.account, source.region, source.note)
+                    """.formatted(table), 3);
+
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    "VALUES " +
+                            "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'updated'), " +
+                            "('shared', CAST(1 AS BIGINT), CAST(20 AS BIGINT), 'sibling'), " +
+                            "('shared', CAST(2 AS BIGINT), CAST(10 AS BIGINT), 'cross-sibling'), " +
+                            "('keep', CAST(3 AS BIGINT), CAST(30 AS BIGINT), 'stable'), " +
+                            "('shared', CAST(4 AS BIGINT), CAST(40 AS BIGINT), 'inserted')");
+        } finally {
+            dropRawTable(table);
+        }
+    }
+
+    @Test
+    public void testPhysicalPrimaryKeyUpdatesAreRejectedWithoutMutation() throws Exception {
+        String table = "update_physical_key_" + uniqueSuffix();
+        String unchangedRows = "VALUES " +
+                "('shared', CAST(1 AS BIGINT), CAST(10 AS BIGINT), 'first'), " +
+                "('shared', CAST(2 AS BIGINT), CAST(20 AS BIGINT), 'second')";
+
+        createRawCompositePrimaryKeyTable(table);
+        try {
+            assertUpdate("INSERT INTO \"" + table + "\" (bucket, account, region, note) VALUES " +
+                    "('shared', 1, 10, 'first'), " +
+                    "('shared', 2, 20, 'second')", 2);
+
+            assertThat(query("UPDATE \"" + table + "\" SET account = 11 WHERE account = 1 AND region = 10"))
+                    .failure()
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("Cannot update YDB primary key column: account");
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    unchangedRows);
+
+            assertThat(query("""
+                    MERGE INTO "%s" target
+                    USING (VALUES (BIGINT '1', BIGINT '10')) AS source(account, region)
+                    ON target.account = source.account AND target.region = source.region
+                    WHEN MATCHED THEN UPDATE SET region = target.region + 10, account = target.account + 10
+                    """.formatted(table)))
+                    .failure()
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("Cannot update YDB primary key columns: account, region");
+            assertQuery(
+                    "SELECT bucket, account, region, note FROM \"" + table + "\" ORDER BY account, region",
+                    unchangedRows);
+        } finally {
+            dropRawTable(table);
+        }
+    }
+
     private static String uniqueSuffix() {
         return UUID.randomUUID().toString().replace("-", "");
     }
@@ -230,6 +309,15 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                 Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE `" + remoteTable + "` " +
                     "(id Int64 NOT NULL, note Utf8, PRIMARY KEY (id))");
+        }
+    }
+
+    private static void createRawCompositePrimaryKeyTable(String remoteTable) throws SQLException {
+        try (Connection connection = DriverManager.getConnection(YdbQueryRunner.buildJdbcUrl(ydb));
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `" + remoteTable + "` " +
+                    "(bucket Utf8, account Int64 NOT NULL, region Int64 NOT NULL, note Utf8, " +
+                    "PRIMARY KEY (account, region))");
         }
     }
 

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbInsertStaging.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbInsertStaging.java
@@ -1,0 +1,107 @@
+package tech.ydb.trino;
+
+import io.trino.plugin.base.mapping.IdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.RemoteTableName;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestYdbInsertStaging {
+    @Test
+    void testCreatesStagingTableWithSerialKeyAndRemoteColumnTypes() {
+        List<JdbcColumnHandle> columns = List.of(
+                column("note", Types.VARCHAR, "Text", VARCHAR, true),
+                column("pk", Types.BIGINT, "Uint64", BIGINT, false),
+                column("_trino_staging_id", Types.INTEGER, "Int32", INTEGER, true));
+        TestingYdbClient client = new TestingYdbClient(columns);
+
+        client.copyTableSchema(
+                null,
+                null,
+                null,
+                null,
+                "dir/target",
+                "dir/staging",
+                List.of("pk", "note", "_trino_staging_id"));
+
+        assertThat(client.executedSql()).isEqualTo(
+                "CREATE TABLE `dir/staging` (`_trino_staging_id_1` BigSerial, " +
+                        "`pk` Uint64 NOT NULL, `note` Text, `_trino_staging_id` Int32, " +
+                        "PRIMARY KEY (`_trino_staging_id_1`))");
+    }
+
+    private static JdbcColumnHandle column(
+            String name,
+            int jdbcType,
+            String remoteType,
+            io.trino.spi.type.Type trinoType,
+            boolean nullable) {
+        return JdbcColumnHandle.builder()
+                .setColumnName(name)
+                .setJdbcTypeHandle(new JdbcTypeHandle(
+                        jdbcType,
+                        Optional.of(remoteType),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()))
+                .setColumnType(trinoType)
+                .setNullable(nullable)
+                .setComment(Optional.empty())
+                .build();
+    }
+
+    private static final class TestingYdbClient extends YdbClient {
+        private final List<JdbcColumnHandle> columns;
+        private String executedSql;
+
+        private TestingYdbClient(List<JdbcColumnHandle> columns) {
+            super(
+                    new BaseJdbcConfig(),
+                    proxy(ConnectionFactory.class),
+                    proxy(QueryBuilder.class),
+                    proxy(IdentifierMapping.class),
+                    RemoteQueryModifier.NONE);
+            this.columns = columns;
+        }
+
+        @Override
+        public List<JdbcColumnHandle> getColumns(
+                ConnectorSession session,
+                SchemaTableName schemaTableName,
+                RemoteTableName remoteTableName) {
+            return columns;
+        }
+
+        @Override
+        protected void execute(ConnectorSession session, Connection connection, String query) throws SQLException {
+            executedSql = query;
+        }
+
+        private String executedSql() {
+            return executedSql;
+        }
+    }
+
+    private static <T> T proxy(Class<T> type) {
+        return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, (_, _, _) -> null));
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbJdbcBatching.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbJdbcBatching.java
@@ -1,0 +1,34 @@
+package tech.ydb.trino;
+
+import org.junit.jupiter.api.Test;
+import tech.ydb.jdbc.common.YdbTypes;
+import tech.ydb.jdbc.query.QueryKey;
+import tech.ydb.jdbc.query.YdbQuery;
+import tech.ydb.jdbc.settings.YdbQueryProperties;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestYdbJdbcBatching
+{
+    @Test
+    void testQueryCommentPreservesAutoBatchRecognition()
+            throws Exception
+    {
+        YdbTypes types = new YdbTypes(false);
+        YdbQueryProperties properties = new YdbQueryProperties(new Properties());
+
+        for (String sql : List.of(
+                "DELETE FROM `orders` WHERE `account` = ? AND `region` = ? /*catalog=ydb*/",
+                "UPDATE `orders` SET `note` = ? WHERE `account` = ? AND `region` = ? /*catalog=ydb*/",
+                "INSERT INTO `orders` (`account`, `region`, `note`) VALUES (?, ?, ?) /*catalog=ydb*/")) {
+            YdbQuery query = YdbQuery.parseQuery(new QueryKey(sql), properties, types);
+
+            assertThat(query.getYqlBatcher())
+                    .as("auto-batch parser for %s", sql)
+                    .isNotNull();
+        }
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.trino.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
@@ -111,6 +112,73 @@ class TestYdbMergeSink {
         assertThat(calls.batchExecutions).hasValue(1);
         assertThat(calls.commits).hasValue(0);
         assertThat(calls.rollbacks).hasValue(1);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
+    void testCleanupFailuresAreSuppressed() {
+        Calls calls = new Calls();
+        SQLException batchFailure = new SQLException("batch failed");
+        SQLException rollbackFailure = new SQLException("rollback failed");
+        SQLException closeFailure = new SQLException("close failed");
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(connection(
+                        statement(calls, batchFailure),
+                        calls,
+                        null,
+                        rollbackFailure,
+                        closeFailure)));
+
+        assertThatThrownBy(mergeSink(jdbcClient)::finish)
+                .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                    assertThat(exception.getCause()).isSameAs(batchFailure);
+                    assertThat(batchFailure.getSuppressed()).containsExactly(rollbackFailure, closeFailure);
+                });
+        assertThat(calls.rollbacks).hasValue(1);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
+    void testSetAutoCommitFailurePreservesCloseFailure() {
+        Calls calls = new Calls();
+        SQLException autoCommitFailure = new SQLException("setAutoCommit failed");
+        SQLException closeFailure = new SQLException("close failed");
+        Connection connection = proxy(Connection.class, (_, method, _) -> switch (method.getName()) {
+            case "setAutoCommit" -> throw autoCommitFailure;
+            case "close" -> {
+                calls.closes.incrementAndGet();
+                throw closeFailure;
+            }
+            default -> null;
+        });
+
+        assertThatThrownBy(mergeSink(jdbcClient(calls, List.of(connection)))::finish)
+                .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                    assertThat(exception.getCause()).isSameAs(autoCommitFailure);
+                    assertThat(autoCommitFailure.getSuppressed()).containsExactly(closeFailure);
+                });
+        assertThat(calls.connections).hasValue(1);
+        assertThat(calls.rollbacks).hasValue(0);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
+    void testCloseFailureAfterCommitPreservesCommittedOutcome() {
+        Calls calls = new Calls();
+        SQLException closeFailure = new SQLException("close failed");
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(connection(statement(calls, null), calls, null, null, closeFailure)));
+
+        assertThatThrownBy(mergeSink(jdbcClient)::finish)
+                .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                    assertThat(exception).hasMessageContaining("committed, but closing its connection failed");
+                    assertThat(exception.getCause()).isSameAs(closeFailure);
+                });
+        assertThat(calls.connections).hasValue(1);
+        assertThat(calls.commits).hasValue(1);
+        assertThat(calls.rollbacks).hasValue(0);
         assertThat(calls.closes).hasValue(1);
     }
 
@@ -204,6 +272,35 @@ class TestYdbMergeSink {
         assertThat(closes).hasValue(1);
     }
 
+    @Test
+    void testRejectsInputBeyondBufferLimitBeforeMutation() {
+        Calls calls = new Calls();
+        ConnectorSession session = proxy(ConnectorSession.class, (_, method, _) ->
+                method.getName().equals("getProperty") ? 1000 : null);
+        Page page = insertPage(42);
+        YdbMergeSink sink = new YdbMergeSink(
+                null,
+                session,
+                mergeHandle(),
+                jdbcClient(calls, List.of()),
+                () -> 1,
+                RemoteQueryModifier.NONE,
+                null,
+                page.getRetainedSizeInBytes());
+
+        sink.storeMergedRows(page);
+        assertThatThrownBy(() -> sink.storeMergedRows(page))
+                .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                    assertThat(exception.getErrorCode()).isEqualTo(EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode());
+                    assertThat(exception).hasMessageContaining("merge.max-buffer-size");
+                });
+        assertThat(sink).extracting("bufferedPages").satisfies(value -> assertThat((List<?>) value).isEmpty());
+        assertThat(sink).extracting("bufferedBytes").isEqualTo(0L);
+        assertThatThrownBy(() -> sink.storeMergedRows(page)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(sink::finish).isInstanceOf(IllegalStateException.class);
+        assertThat(calls.connections).hasValue(0);
+    }
+
     private static YdbMergeSink mergeSink(JdbcClient jdbcClient) {
         return mergeSink(jdbcClient, 1000, insertPage(42));
     }
@@ -230,7 +327,8 @@ class TestYdbMergeSink {
                 jdbcClient,
                 () -> 1,
                 RemoteQueryModifier.NONE,
-                null);
+                null,
+                Long.MAX_VALUE);
         for (Page page : pages) {
             sink.storeMergedRows(page);
         }
@@ -270,6 +368,15 @@ class TestYdbMergeSink {
     }
 
     private static Connection connection(PreparedStatement statement, Calls calls, SQLException commitFailure) {
+        return connection(statement, calls, commitFailure, null, null);
+    }
+
+    private static Connection connection(
+            PreparedStatement statement,
+            Calls calls,
+            SQLException commitFailure,
+            SQLException rollbackFailure,
+            SQLException closeFailure) {
         return proxy(Connection.class, (_, method, _) -> switch (method.getName()) {
             case "setAutoCommit" -> null;
             case "prepareStatement" -> statement;
@@ -282,10 +389,16 @@ class TestYdbMergeSink {
             }
             case "rollback" -> {
                 calls.rollbacks.incrementAndGet();
+                if (rollbackFailure != null) {
+                    throw rollbackFailure;
+                }
                 yield null;
             }
             case "close" -> {
                 calls.closes.incrementAndGet();
+                if (closeFailure != null) {
+                    throw closeFailure;
+                }
                 yield null;
             }
             default -> null;

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
@@ -1,0 +1,204 @@
+package tech.ydb.trino;
+
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMergeTableHandle;
+import io.trino.plugin.jdbc.JdbcOutputTableHandle;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.RemoteTableName;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+import tech.ydb.core.Status;
+import tech.ydb.core.StatusCode;
+import tech.ydb.jdbc.exception.YdbStatusable;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestYdbMergeSink {
+    @Test
+    void testCommitFailureIsNotRetried() {
+        Calls calls = new Calls();
+        SQLException commitFailure = new RetryableSQLException();
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(connection(statement(calls, null), calls, commitFailure)));
+
+        assertThatThrownBy(mergeSink(jdbcClient)::finish)
+                .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                    assertThat(exception).hasMessageContaining("commit outcome is unknown");
+                    assertThat(exception.getCause()).isSameAs(commitFailure);
+                });
+        assertThat(calls.connections).hasValue(1);
+        assertThat(calls.batchExecutions).hasValue(1);
+        assertThat(calls.commits).hasValue(1);
+        assertThat(calls.rollbacks).hasValue(1);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
+    void testPreCommitFailureRetriesOnFreshConnection() {
+        Calls calls = new Calls();
+        SQLException firstBatchFailure = new RetryableSQLException();
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(
+                        connection(statement(calls, firstBatchFailure), calls, null),
+                        connection(statement(calls, null), calls, null)));
+
+        mergeSink(jdbcClient).finish();
+
+        assertThat(calls.connections).hasValue(2);
+        assertThat(calls.batchExecutions).hasValue(2);
+        assertThat(calls.commits).hasValue(1);
+        assertThat(calls.rollbacks).hasValue(1);
+        assertThat(calls.closes).hasValue(2);
+    }
+
+    private static YdbMergeSink mergeSink(JdbcClient jdbcClient) {
+        YdbMergeSink sink = new YdbMergeSink(
+                null,
+                null,
+                mergeHandle(),
+                jdbcClient,
+                () -> 1,
+                RemoteQueryModifier.NONE,
+                null);
+        sink.storeMergedRows(insertPage());
+        return sink;
+    }
+
+    private static JdbcClient jdbcClient(Calls calls, List<Connection> connections) {
+        return proxy(JdbcClient.class, (_, method, _) -> switch (method.getName()) {
+            case "getConnection" -> connections.get(calls.connections.getAndIncrement());
+            case "toWriteMapping" -> WriteMapping.longMapping("Int64", PreparedStatement::setLong);
+            case "buildInsertSql" -> "INSERT INTO `target` (`value`) VALUES (?)";
+            default -> null;
+        });
+    }
+
+    private static PreparedStatement statement(Calls calls, SQLException batchFailure) {
+        return proxy(PreparedStatement.class, (_, method, _) -> {
+            if (!method.getName().equals("executeBatch")) {
+                return null;
+            }
+            calls.batchExecutions.incrementAndGet();
+            if (batchFailure != null) {
+                throw batchFailure;
+            }
+            return new int[] {1};
+        });
+    }
+
+    private static Connection connection(PreparedStatement statement, Calls calls, SQLException commitFailure) {
+        return proxy(Connection.class, (_, method, _) -> switch (method.getName()) {
+            case "setAutoCommit" -> null;
+            case "prepareStatement" -> statement;
+            case "commit" -> {
+                calls.commits.incrementAndGet();
+                if (commitFailure != null) {
+                    throw commitFailure;
+                }
+                yield null;
+            }
+            case "rollback" -> {
+                calls.rollbacks.incrementAndGet();
+                yield null;
+            }
+            case "close" -> {
+                calls.closes.incrementAndGet();
+                yield null;
+            }
+            default -> null;
+        });
+    }
+
+    private static JdbcMergeTableHandle mergeHandle() {
+        RemoteTableName remoteTableName = new RemoteTableName(Optional.empty(), Optional.empty(), "target");
+        JdbcOutputTableHandle outputHandle = new JdbcOutputTableHandle(
+                remoteTableName,
+                List.of("value"),
+                List.of(BIGINT),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        JdbcTableHandle tableHandle = new JdbcTableHandle(
+                new SchemaTableName("default", "target"),
+                remoteTableName,
+                Optional.empty());
+        return new JdbcMergeTableHandle(
+                tableHandle,
+                outputHandle,
+                Map.of(),
+                Optional.empty(),
+                List.of(),
+                List.of(),
+                Map.of());
+    }
+
+    private static Page insertPage() {
+        Block value = bigintBlock(42);
+        return new Page(
+                value,
+                tinyintBlock(INSERT_OPERATION_NUMBER),
+                integerBlock(0),
+                RowBlock.fromFieldBlocks(1, new Block[] {value}));
+    }
+
+    private static Block bigintBlock(long value) {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(1);
+        BIGINT.writeLong(builder, value);
+        return builder.build();
+    }
+
+    private static Block integerBlock(int value) {
+        BlockBuilder builder = INTEGER.createFixedSizeBlockBuilder(1);
+        INTEGER.writeLong(builder, value);
+        return builder.build();
+    }
+
+    private static Block tinyintBlock(int value) {
+        BlockBuilder builder = TINYINT.createFixedSizeBlockBuilder(1);
+        TINYINT.writeLong(builder, value);
+        return builder.build();
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler));
+    }
+
+    private static final class Calls {
+        private final AtomicInteger connections = new AtomicInteger();
+        private final AtomicInteger batchExecutions = new AtomicInteger();
+        private final AtomicInteger commits = new AtomicInteger();
+        private final AtomicInteger rollbacks = new AtomicInteger();
+        private final AtomicInteger closes = new AtomicInteger();
+    }
+
+    private static final class RetryableSQLException extends SQLException implements YdbStatusable {
+        @Override
+        public Status getStatus() {
+            return Status.of(StatusCode.ABORTED);
+        }
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
@@ -1,9 +1,11 @@
 package tech.ydb.trino;
 
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcMergeTableHandle;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
@@ -12,6 +14,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RowBlock;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import org.junit.jupiter.api.Test;
 import tech.ydb.core.Status;
@@ -23,12 +26,18 @@ import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.trino.spi.connector.ConnectorMergeSink.DELETE_OPERATION_NUMBER;
 import static io.trino.spi.connector.ConnectorMergeSink.INSERT_OPERATION_NUMBER;
+import static io.trino.spi.connector.ConnectorMergeSink.UPDATE_OPERATION_NUMBER;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -63,28 +72,138 @@ class TestYdbMergeSink {
         JdbcClient jdbcClient = jdbcClient(
                 calls,
                 List.of(
-                        connection(statement(calls, firstBatchFailure), calls, null),
+                        connection(statement(calls, 2, firstBatchFailure), calls, null),
                         connection(statement(calls, null), calls, null)));
 
-        mergeSink(jdbcClient).finish();
+        mergeSink(jdbcClient, 2, insertPage(1, 2, 3)).finish();
 
         assertThat(calls.connections).hasValue(2);
-        assertThat(calls.batchExecutions).hasValue(2);
+        assertThat(calls.batchSizes).containsExactly(2, 1, 2, 1);
         assertThat(calls.commits).hasValue(1);
         assertThat(calls.rollbacks).hasValue(1);
         assertThat(calls.closes).hasValue(2);
     }
 
+    @Test
+    void testSplitsBatchWithoutIntermediateCommit() {
+        Calls calls = new Calls();
+        PreparedStatement statement = statement(calls, null);
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(connection(statement, calls, null)));
+
+        mergeSink(jdbcClient, 2, insertPage(1, 2, 3, 4, 5)).finish();
+
+        assertThat(calls.batchSizes).containsExactly(2, 2, 1);
+        assertThat(calls.commits).hasValue(1);
+        assertThat(calls.rollbacks).hasValue(0);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
+    void testStreamsOperationsInPhaseAndColumnOrder() {
+        List<String> events = new ArrayList<>();
+        StatementRecorder delete = new StatementRecorder("delete", events);
+        StatementRecorder update = new StatementRecorder("update", events);
+        StatementRecorder insert = new StatementRecorder("insert", events);
+        List<StatementRecorder> statements = List.of(delete, update, insert);
+        AtomicInteger preparedStatements = new AtomicInteger();
+        Connection connection = proxy(Connection.class, (_, method, _) -> switch (method.getName()) {
+            case "setAutoCommit", "close" -> null;
+            case "prepareStatement" -> statements.get(preparedStatements.getAndIncrement()).statement();
+            case "commit" -> {
+                events.add("commit");
+                yield null;
+            }
+            default -> null;
+        });
+        JdbcClient jdbcClient = proxy(JdbcClient.class, (_, method, arguments) -> switch (method.getName()) {
+            case "getConnection" -> connection;
+            case "quoted" -> "`" + arguments[0] + "`";
+            case "toWriteMapping" -> WriteMapping.longMapping("Int64", PreparedStatement::setLong);
+            case "buildInsertSql" -> "INSERT";
+            default -> null;
+        });
+
+        mergeSink(jdbcClient, 10, mixedMergeHandle(), mixedPage()).finish();
+
+        assertThat(preparedStatements).hasValue(3);
+        assertThat(events).containsExactly("delete", "update", "insert", "commit");
+        assertThat(delete.rows()).containsExactly(List.of(13L, 130L));
+        assertThat(update.rows()).containsExactly(List.of(200L, 2000L, 12L, 120L));
+        assertThat(insert.rows()).containsExactly(List.of(100L, 1L, 10L, 1000L));
+    }
+
+    @Test
+    void testRejectsUnknownUpdateCaseBeforeMutation() {
+        AtomicInteger preparedStatements = new AtomicInteger();
+        AtomicInteger commits = new AtomicInteger();
+        AtomicInteger rollbacks = new AtomicInteger();
+        AtomicInteger closes = new AtomicInteger();
+        Connection connection = proxy(Connection.class, (_, method, _) -> switch (method.getName()) {
+            case "setAutoCommit" -> null;
+            case "prepareStatement" -> {
+                preparedStatements.incrementAndGet();
+                yield null;
+            }
+            case "commit" -> {
+                commits.incrementAndGet();
+                yield null;
+            }
+            case "rollback" -> {
+                rollbacks.incrementAndGet();
+                yield null;
+            }
+            case "close" -> {
+                closes.incrementAndGet();
+                yield null;
+            }
+            default -> null;
+        });
+        JdbcClient jdbcClient = proxy(JdbcClient.class, (_, method, _) ->
+                method.getName().equals("getConnection") ? connection : null);
+
+        assertThatThrownBy(() -> mergeSink(jdbcClient, 10, mixedMergeHandle(), unknownUpdateCasePage()).finish())
+                .isInstanceOfSatisfying(TrinoException.class, exception ->
+                        assertThat(exception.getCause())
+                                .isInstanceOf(IllegalStateException.class)
+                                .hasMessage("No columns for MERGE update case 99"));
+        assertThat(preparedStatements).hasValue(0);
+        assertThat(commits).hasValue(0);
+        assertThat(rollbacks).hasValue(1);
+        assertThat(closes).hasValue(1);
+    }
+
     private static YdbMergeSink mergeSink(JdbcClient jdbcClient) {
+        return mergeSink(jdbcClient, 1000, insertPage(42));
+    }
+
+    private static YdbMergeSink mergeSink(JdbcClient jdbcClient, int maxBatchSize, Page... pages) {
+        return mergeSink(jdbcClient, maxBatchSize, mergeHandle(), pages);
+    }
+
+    private static YdbMergeSink mergeSink(
+            JdbcClient jdbcClient,
+            int maxBatchSize,
+            JdbcMergeTableHandle mergeHandle,
+            Page... pages) {
+        ConnectorSession session = proxy(ConnectorSession.class, (_, method, _) -> {
+            if (method.getName().equals("getProperty")) {
+                return maxBatchSize;
+            }
+            return null;
+        });
         YdbMergeSink sink = new YdbMergeSink(
                 null,
-                null,
-                mergeHandle(),
+                session,
+                mergeHandle,
                 jdbcClient,
                 () -> 1,
                 RemoteQueryModifier.NONE,
                 null);
-        sink.storeMergedRows(insertPage());
+        for (Page page : pages) {
+            sink.storeMergedRows(page);
+        }
         return sink;
     }
 
@@ -98,15 +217,25 @@ class TestYdbMergeSink {
     }
 
     private static PreparedStatement statement(Calls calls, SQLException batchFailure) {
-        return proxy(PreparedStatement.class, (_, method, _) -> {
-            if (!method.getName().equals("executeBatch")) {
-                return null;
+        return statement(calls, 1, batchFailure);
+    }
+
+    private static PreparedStatement statement(Calls calls, int failureExecution, SQLException batchFailure) {
+        AtomicInteger executions = new AtomicInteger();
+        return proxy(PreparedStatement.class, (_, method, _) -> switch (method.getName()) {
+            case "addBatch" -> {
+                calls.pendingBatchRows.incrementAndGet();
+                yield null;
             }
-            calls.batchExecutions.incrementAndGet();
-            if (batchFailure != null) {
-                throw batchFailure;
+            case "executeBatch" -> {
+                calls.batchExecutions.incrementAndGet();
+                calls.batchSizes.add(calls.pendingBatchRows.getAndSet(0));
+                if (batchFailure != null && executions.incrementAndGet() == failureExecution) {
+                    throw batchFailure;
+                }
+                yield new int[] {1};
             }
-            return new int[] {1};
+            default -> null;
         });
     }
 
@@ -156,31 +285,114 @@ class TestYdbMergeSink {
                 Map.of());
     }
 
-    private static Page insertPage() {
-        Block value = bigintBlock(42);
+    private static JdbcMergeTableHandle mixedMergeHandle() {
+        RemoteTableName remoteTableName = new RemoteTableName(Optional.empty(), Optional.empty(), "target");
+        List<JdbcColumnHandle> columns = List.of(
+                column("leading"),
+                column("pk1"),
+                column("pk2"),
+                column("value"));
+        JdbcOutputTableHandle outputHandle = new JdbcOutputTableHandle(
+                remoteTableName,
+                columns.stream().map(JdbcColumnHandle::getColumnName).toList(),
+                columns.stream().map(JdbcColumnHandle::getColumnType).toList(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        JdbcTableHandle tableHandle = new JdbcTableHandle(
+                new SchemaTableName("default", "target"),
+                remoteTableName,
+                Optional.empty());
+        return new JdbcMergeTableHandle(
+                tableHandle,
+                outputHandle,
+                Map.of(),
+                Optional.empty(),
+                List.of(columns.get(1), columns.get(2)),
+                columns,
+                Map.of(0, List.of(columns.get(3), columns.get(0))));
+    }
+
+    private static JdbcColumnHandle column(String name) {
+        return new JdbcColumnHandle(
+                name,
+                new JdbcTypeHandle(
+                        Types.BIGINT,
+                        Optional.of("Int64"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                BIGINT);
+    }
+
+    private static Page insertPage(long... values) {
+        Block valueBlock = bigintBlock(values);
         return new Page(
-                value,
-                tinyintBlock(INSERT_OPERATION_NUMBER),
-                integerBlock(0),
-                RowBlock.fromFieldBlocks(1, new Block[] {value}));
+                valueBlock,
+                tinyintBlock(repeat(INSERT_OPERATION_NUMBER, values.length)),
+                integerBlock(new int[values.length]),
+                RowBlock.fromFieldBlocks(values.length, new Block[] {valueBlock}));
     }
 
-    private static Block bigintBlock(long value) {
-        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(1);
-        BIGINT.writeLong(builder, value);
+    private static Page mixedPage() {
+        return new Page(
+                bigintBlock(100, 200, 300),
+                bigintBlock(1, 2, 3),
+                bigintBlock(10, 20, 30),
+                bigintBlock(1000, 2000, 3000),
+                tinyintBlock(INSERT_OPERATION_NUMBER, UPDATE_OPERATION_NUMBER, DELETE_OPERATION_NUMBER),
+                integerBlock(0, 0, 0),
+                RowBlock.fromFieldBlocks(
+                        3,
+                        new Block[] {
+                                bigintBlock(11, 12, 13),
+                                bigintBlock(110, 120, 130)}));
+    }
+
+    private static Page unknownUpdateCasePage() {
+        return new Page(
+                bigintBlock(100),
+                bigintBlock(1),
+                bigintBlock(10),
+                bigintBlock(1000),
+                tinyintBlock(UPDATE_OPERATION_NUMBER),
+                integerBlock(99),
+                RowBlock.fromFieldBlocks(
+                        1,
+                        new Block[] {
+                                bigintBlock(1),
+                                bigintBlock(10)}));
+    }
+
+    private static Block bigintBlock(long... values) {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(values.length);
+        for (long value : values) {
+            BIGINT.writeLong(builder, value);
+        }
         return builder.build();
     }
 
-    private static Block integerBlock(int value) {
-        BlockBuilder builder = INTEGER.createFixedSizeBlockBuilder(1);
-        INTEGER.writeLong(builder, value);
+    private static Block integerBlock(int... values) {
+        BlockBuilder builder = INTEGER.createFixedSizeBlockBuilder(values.length);
+        for (int value : values) {
+            INTEGER.writeLong(builder, value);
+        }
         return builder.build();
     }
 
-    private static Block tinyintBlock(int value) {
-        BlockBuilder builder = TINYINT.createFixedSizeBlockBuilder(1);
-        TINYINT.writeLong(builder, value);
+    private static Block tinyintBlock(int... values) {
+        BlockBuilder builder = TINYINT.createFixedSizeBlockBuilder(values.length);
+        for (int value : values) {
+            TINYINT.writeLong(builder, value);
+        }
         return builder.build();
+    }
+
+    private static int[] repeat(int value, int count) {
+        int[] values = new int[count];
+        Arrays.fill(values, value);
+        return values;
     }
 
     private static <T> T proxy(Class<T> type, InvocationHandler handler) {
@@ -190,9 +402,48 @@ class TestYdbMergeSink {
     private static final class Calls {
         private final AtomicInteger connections = new AtomicInteger();
         private final AtomicInteger batchExecutions = new AtomicInteger();
+        private final AtomicInteger pendingBatchRows = new AtomicInteger();
         private final AtomicInteger commits = new AtomicInteger();
         private final AtomicInteger rollbacks = new AtomicInteger();
         private final AtomicInteger closes = new AtomicInteger();
+        private final List<Integer> batchSizes = new ArrayList<>();
+    }
+
+    private static final class StatementRecorder {
+        private final String name;
+        private final List<String> events;
+        private final Map<Integer, Long> currentRow = new TreeMap<>();
+        private final List<List<Long>> rows = new ArrayList<>();
+        private final PreparedStatement statement;
+
+        private StatementRecorder(String name, List<String> events) {
+            this.name = name;
+            this.events = events;
+            this.statement = proxy(PreparedStatement.class, (_, method, arguments) -> switch (method.getName()) {
+                case "setLong" -> {
+                    currentRow.put((Integer) arguments[0], (Long) arguments[1]);
+                    yield null;
+                }
+                case "addBatch" -> {
+                    rows.add(List.copyOf(currentRow.values()));
+                    currentRow.clear();
+                    yield null;
+                }
+                case "executeBatch" -> {
+                    events.add(name);
+                    yield new int[rows.size()];
+                }
+                default -> null;
+            });
+        }
+
+        private PreparedStatement statement() {
+            return statement;
+        }
+
+        private List<List<Long>> rows() {
+            return rows;
+        }
     }
 
     private static final class RetryableSQLException extends SQLException implements YdbStatusable {

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbMergeSink.java
@@ -85,6 +85,36 @@ class TestYdbMergeSink {
     }
 
     @Test
+    void testInterruptedRetryPreservesSqlFailureAndCleanup() {
+        Calls calls = new Calls();
+        SQLException batchFailure = new RetryableSQLException();
+        JdbcClient jdbcClient = jdbcClient(
+                calls,
+                List.of(connection(statement(calls, batchFailure), calls, null)));
+
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(mergeSink(jdbcClient)::finish)
+                    .isInstanceOfSatisfying(TrinoException.class, exception -> {
+                        assertThat(exception).hasMessageContaining("Interrupted while waiting to retry");
+                        assertThat(exception.getCause()).isSameAs(batchFailure);
+                        assertThat(batchFailure.getSuppressed()).hasSize(1);
+                        assertThat(batchFailure.getSuppressed()[0]).isInstanceOf(InterruptedException.class);
+                    });
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        }
+        finally {
+            Thread.interrupted();
+        }
+
+        assertThat(calls.connections).hasValue(1);
+        assertThat(calls.batchExecutions).hasValue(1);
+        assertThat(calls.commits).hasValue(0);
+        assertThat(calls.rollbacks).hasValue(1);
+        assertThat(calls.closes).hasValue(1);
+    }
+
+    @Test
     void testSplitsBatchWithoutIntermediateCommit() {
         Calls calls = new Calls();
         PreparedStatement statement = statement(calls, null);

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbRetryUtils.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbRetryUtils.java
@@ -1,0 +1,46 @@
+package tech.ydb.trino;
+
+import org.junit.jupiter.api.Test;
+import tech.ydb.core.Status;
+import tech.ydb.core.StatusCode;
+import tech.ydb.jdbc.exception.YdbStatusable;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestYdbRetryUtils {
+    @Test
+    void testRetriesOnlyUnconditionalStatusesFromPinnedSdk() {
+        assertThat(Arrays.stream(StatusCode.values())
+                .filter(code -> YdbRetryUtils.isRetryable(new StatusSQLException(code))))
+                .containsExactlyInAnyOrder(
+                        StatusCode.ABORTED,
+                        StatusCode.UNAVAILABLE,
+                        StatusCode.OVERLOADED,
+                        StatusCode.BAD_SESSION,
+                        StatusCode.SESSION_BUSY,
+                        StatusCode.CLIENT_RESOURCE_EXHAUSTED);
+    }
+
+    @Test
+    void testFindsYdbStatusInCauseChain() {
+        SQLException statusException = new StatusSQLException(StatusCode.ABORTED);
+
+        assertThat(YdbRetryUtils.isRetryable(new SQLException("wrapper", statusException))).isTrue();
+    }
+
+    private static final class StatusSQLException extends SQLException implements YdbStatusable {
+        private final Status status;
+
+        private StatusSQLException(StatusCode statusCode) {
+            this.status = Status.of(statusCode);
+        }
+
+        @Override
+        public Status getStatus() {
+            return status;
+        }
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -48,6 +48,25 @@ class TestYdbTablePath
     }
 
     @Test
+    void testPathDepth()
+    {
+        String maximumDepthPath = "a/".repeat(31) + "a";
+        String excessiveDepthPath = maximumDepthPath + "/a";
+
+        assertThat(YdbTablePath.fromUserInput(maximumDepthPath).value()).isEqualTo(maximumDepthPath);
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput(excessiveDepthPath))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("too deep")
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+
+        assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata(excessiveDepthPath))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(JDBC_ERROR.toErrorCode());
+    }
+
+    @Test
     void testDataSystemTableName()
     {
         assertThat(YdbTablePath.isDataSystemTableName("nation$data")).isTrue();

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbTablePath.java
@@ -1,0 +1,86 @@
+package tech.ydb.trino;
+
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestYdbTablePath
+{
+    @Test
+    void testValidUserPaths()
+    {
+        assertThat(YdbTablePath.fromUserInput("orders").value()).isEqualTo("orders");
+        assertThat(YdbTablePath.fromUserInput("sales/eu/orders").value()).isEqualTo("sales/eu/orders");
+        assertThat(YdbTablePath.fromUserInput("sales.eu/orders-v2").comparisonKey())
+                .isEqualTo("sales.eu/orders-v2");
+    }
+
+    @Test
+    void testInvalidUserPaths()
+    {
+        for (String path : new String[] {"", "/orders", "orders/", "a//b", ".", "..", "a/../b", ".sys/table", "a/$/b"}) {
+            assertThatThrownBy(() -> YdbTablePath.fromUserInput(path))
+                    .isInstanceOf(TrinoException.class)
+                    .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                    .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+        }
+    }
+
+    @Test
+    void testComponentLength()
+    {
+        String nestedPath = "a".repeat(127) + "/" + "b".repeat(128);
+
+        assertThat(YdbTablePath.fromUserInput("a".repeat(255)).value()).hasSize(255);
+        assertThat(YdbTablePath.fromUserInput(nestedPath).value()).isEqualTo(nestedPath);
+
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+
+        assertThatThrownBy(() -> YdbTablePath.fromUserInput("a".repeat(256)))
+                .hasMessageContaining("too long");
+    }
+
+    @Test
+    void testDataSystemTableName()
+    {
+        assertThat(YdbTablePath.isDataSystemTableName("nation$data")).isTrue();
+        assertThat(YdbTablePath.isDataSystemTableName("a".repeat(255) + "$data")).isTrue();
+        assertThat(YdbTablePath.isDataSystemTableName(
+                "a".repeat(127) + "/" + "b".repeat(128) + "$data")).isTrue();
+
+        for (String path : new String[] {"$data", "a/$data", "a$bad$data", "a".repeat(256) + "$data"}) {
+            assertThat(YdbTablePath.isDataSystemTableName(path)).isFalse();
+            assertThatThrownBy(() -> YdbTablePath.fromUserInput(path))
+                    .isInstanceOf(TrinoException.class)
+                    .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                    .isEqualTo(INVALID_ARGUMENTS.toErrorCode());
+        }
+    }
+
+    @Test
+    void testRemoteMetadataPaths()
+    {
+        String nestedPath = "a".repeat(127) + "/" + "b".repeat(128);
+
+        assertThat(YdbTablePath.fromRemoteMetadata(".sys/table")).isEmpty();
+        assertThat(YdbTablePath.fromRemoteMetadata(".sys/" + "a".repeat(251))).isEmpty();
+        assertThat(YdbTablePath.fromRemoteMetadata(nestedPath)).contains(new YdbTablePath(nestedPath));
+
+        assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/$/b"))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(JDBC_ERROR.toErrorCode());
+
+        assertThatThrownBy(() -> YdbTablePath.fromRemoteMetadata("a/" + "b".repeat(256)))
+                .isInstanceOf(TrinoException.class)
+                .extracting(exception -> ((TrinoException) exception).getErrorCode())
+                .isEqualTo(JDBC_ERROR.toErrorCode());
+    }
+}

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestingYdbJdbcModule.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestingYdbJdbcModule.java
@@ -14,7 +14,9 @@ import io.trino.plugin.jdbc.JdbcMetadataFactory;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class TestingYdbJdbcModule implements Module {
 
@@ -27,6 +29,7 @@ public class TestingYdbJdbcModule implements Module {
 
         binder.bind(YdbPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(YdbConnector.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(YdbConfig.class);
     }
 
     @Provides

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
@@ -9,7 +9,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchColumn;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
-import tech.ydb.test.junit5.YdbHelperExtension;
+import tech.ydb.test.integration.YdbHelper;
 
 import java.util.HashMap;
 import java.util.List;
@@ -24,15 +24,19 @@ public final class YdbQueryRunner {
 
     private YdbQueryRunner() {}
 
-    public static Builder builder(YdbHelperExtension ydb) {
-        String jdbcUrl = buildJdbcUrl(ydb);
-        return new Builder()
-                // Avoid temporary-table CTAS during INSERT; YDB does not support CREATE TABLE AS SELECT.
-                .addConnectorProperty("insert.non-transactional-insert.enabled", "true")
-                .addConnectorProperty("connection-url", jdbcUrl);
+    public static Builder builder(YdbHelper ydb) {
+        Builder builder = new Builder();
+        connectorProperties(ydb).forEach(builder::addConnectorProperty);
+        return builder;
     }
 
-    static String buildJdbcUrl(YdbHelperExtension ydb) {
+    static Map<String, String> connectorProperties(YdbHelper ydb) {
+        return ImmutableMap.of(
+                "insert.non-transactional-insert.enabled", "true",
+                "connection-url", buildJdbcUrl(ydb));
+    }
+
+    static String buildJdbcUrl(YdbHelper ydb) {
         StringBuilder url = new StringBuilder("jdbc:ydb:");
         url.append(ydb.useTls() ? "grpcs://" : "grpc://");
         url.append(ydb.endpoint());

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/YdbQueryRunner.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public final class YdbQueryRunner {
-    public static final String TPCH_SCHEMA = "ydb";
+    public static final String DEFAULT_SCHEMA = YdbClient.DEFAULT_SCHEMA;
     public static final String YDB_HIDDEN_PK_COLUMN = TestingYdbJdbcClient.YDB_HIDDEN_PK_COLUMN;
 
     private YdbQueryRunner() {}
@@ -32,7 +32,7 @@ public final class YdbQueryRunner {
                 .addConnectorProperty("connection-url", jdbcUrl);
     }
 
-    private static String buildJdbcUrl(YdbHelperExtension ydb) {
+    static String buildJdbcUrl(YdbHelperExtension ydb) {
         StringBuilder url = new StringBuilder("jdbc:ydb:");
         url.append(ydb.useTls() ? "grpcs://" : "grpc://");
         url.append(ydb.endpoint());
@@ -51,7 +51,7 @@ public final class YdbQueryRunner {
         private Builder() {
             super(testSessionBuilder()
                     .setCatalog("ydb")
-                    .setSchema(TPCH_SCHEMA)
+                    .setSchema(DEFAULT_SCHEMA)
                     .build());
         }
 


### PR DESCRIPTION
## Summary

- define one-catalog/one-database `default` namespace semantics with safe nested YDB paths and verified cross-catalog federation
- harden UPDATE/DELETE/MERGE key, retry, transaction, commit-ambiguity, batching, and retained-memory contracts
- add YDB-native transactional INSERT staging and `Date32`/`Datetime64`/`Timestamp64` support using `forceSignedDatetimes=true`
- audit Trino 479 capabilities and document concrete unsupported boundaries instead of advertising incomplete behavior

The final review also aligned `Timestamp64` predicate pushdown with the pinned JDBC 2.3.18 upper boundary and made MERGE buffer-limit failures release retained pages and terminate the sink before any remote mutation.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 25) DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock mvn --batch-mode --update-snapshots -f ydb-trino-adapter/pom.xml clean test`
  - 364 total, 280 passed, 0 failures, 0 errors, 84 skipped
  - Connector: 291 total / 80 skipped
  - Smoke: 36 total / 4 skipped
  - Federation: 6 total / 0 skipped
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn --batch-mode -f ydb-trino-adapter/pom.xml -DskipTests package`
  - plugin JAR, service descriptor, `YdbPlugin`, and `YdbConfig` verified

## Compatibility and limitations

- Trino 479, JDK 25, YDB JDBC 2.3.18 (SDK 2.3.20)
- one catalog per configured YDB database; `default` is the only virtual schema
- no `TRUNCATE`, dynamic database switching, cross-catalog snapshot/distributed commit, or replay after an ambiguous MERGE commit
- DEFAULT capability remains false because the inherited Trino contract includes unsupported `DEFAULT NULL`, `SET/DROP DEFAULT`, and MERGE-default cases
- the YDB test-helper image is intentionally unpinned; this local run is not presented as an image-version compatibility baseline

Related: https://github.com/trinodb/trino/issues/28110
