### PR TITLE
Map YDB Bytes to Trino varbinary

### DIFF
--- a/ydb-trino-adapter/README.md
+++ b/ydb-trino-adapter/README.md
@@ -44,3 +44,8 @@ SELECT * FROM local.default.orders;
 ```
 
 Прежние обращения `catalog.ydb.table` нужно заменить на `catalog.default.table`.
+
+## Текст и байты
+
+YDB `Text` отображается в Trino как `varchar`, а `Bytes` — как `varbinary` без
+декодирования UTF-8. При создании таблиц адаптер использует типы `Text` и `Bytes`.

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -100,6 +100,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
@@ -114,6 +116,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Math.max;
@@ -279,13 +282,11 @@ public class YdbClient extends BaseJdbcClient {
             return mapping;
         }
 
-        // YDB JDBC reports text columns as Bytes/String/Utf8/Text under various JDBC type codes.
-        // Always map them to unbounded varchar (YDB Text has no useful fixed length).
         String jdbcTypeName = typeHandle.jdbcTypeName().orElse("").toLowerCase(Locale.ROOT);
-        if (jdbcTypeName.equals("bytes")
-                || jdbcTypeName.equals("string")
-                || jdbcTypeName.equals("utf8")
-                || jdbcTypeName.equals("text")) {
+        if (jdbcTypeName.equals("bytes") || jdbcTypeName.equals("string")) {
+            return Optional.of(varbinaryColumnMapping());
+        }
+        if (jdbcTypeName.equals("utf8") || jdbcTypeName.equals("text")) {
             return Optional.of(unboundedVarcharColumnMapping());
         }
 
@@ -414,6 +415,9 @@ public class YdbClient extends BaseJdbcClient {
         }
         if (type instanceof VarcharType) {
             return WriteMapping.sliceMapping("Text", varcharWriteFunction());
+        }
+        if (type == VARBINARY) {
+            return WriteMapping.sliceMapping("Bytes", varbinaryWriteFunction());
         }
         if (type == DATE) {
             return WriteMapping.longMapping("Date", dateWriteFunctionUsingLocalDate());

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTypeUtils.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbTypeUtils.java
@@ -35,6 +35,10 @@ public final class YdbTypeUtils {
                     Optional.of(new JdbcTypeHandle(Types.TIMESTAMP, Optional.of("Timestamp"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             case DecimalType decimalType ->
                     Optional.of(new JdbcTypeHandle(Types.DECIMAL, Optional.of("Decimal"), Optional.of(decimalType.getPrecision()), Optional.of(decimalType.getScale()), Optional.empty(), Optional.empty()));
+            case io.trino.spi.type.VarcharType _ ->
+                    Optional.of(new JdbcTypeHandle(Types.VARCHAR, Optional.of("Text"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+            case io.trino.spi.type.VarbinaryType _ ->
+                    Optional.of(new JdbcTypeHandle(Types.BINARY, Optional.of("Bytes"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
             default ->
                     Optional.of(new JdbcTypeHandle(Types.VARCHAR, Optional.of("String"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         };

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -154,11 +154,19 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                     "DATE '2006-06-06'",
                     "DATE '2026-06-06'"
             ));
-        } else if (dataMappingTestSetup.getTrinoTypeName().startsWith("time") || dataMappingTestSetup.getTrinoTypeName().equals("varbinary")) {
-            // Нет time и varbinary в YQL
+        } else if (dataMappingTestSetup.getTrinoTypeName().startsWith("time")) {
+            // Нет time в YQL
             return Optional.empty();
         }
         return Optional.of(dataMappingTestSetup);
+    }
+
+    @Test
+    public void testVarbinaryCreateTableAndInsert() {
+        try (TestTable table = newTrinoTable("varbinary_insert_", "(id bigint, value varbinary)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, X'0080FF')", 1);
+            assertQuery("SELECT value FROM " + table.getName(), "VALUES X'0080FF'");
+        }
     }
 
     @Override


### PR DESCRIPTION
## Pull request type

- [x] Feature

## What is the current behavior?

YDB native Bytes columns are exposed as varchar, so JDBC getString can lose arbitrary byte sequences.

## What is the new behavior?

- Map native Bytes and compatibility String metadata to Trino varbinary through byte-preserving JDBC mappings.
- Keep Text and Utf8 mapped to varchar; write Trino varbinary as YDB Bytes.
- Restore the inherited varbinary data-mapping smoke case and add a focused CREATE TABLE + INSERT regression for X'0080FF'.

## Validation

- JDK 25 compile passed: `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -f ydb-trino-adapter/pom.xml -DskipTests compile`.
- `TestYdbConnectorTest#testDataMappingSmokeTest` was not executed: framework initialization failed before the method because the local Colima Docker socket was unavailable (ProxyYdbHelper/Testcontainers initialization error).
- Full clean suite was not run because it would encounter the same Docker initialization blocker.