### PR TITLE
test: restore inherited varchar date predicate

### DIFF
--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -136,7 +136,7 @@ unsupported behavior, record:
 2. an authoritative documentation link or tracked upstream issue;
 3. a focused negative test that proves the connector fails clearly.
 
-The existing negative-date and cast-pushdown overrides need this treatment.
+The existing negative-date overrides need this treatment.
 YDB `Date` starts at the Unix epoch; see
 [primitive types](https://ydb.tech/docs/en/yql/reference/types/primitive).
 CHAR is rejected with the focused inherited contract

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -110,12 +110,6 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
                 .hasMessage("Unsupported column type: char(3)");
     }
 
-    @Test
-    @Override
-    public void testVarcharCastToDateInPredicate() {
-        // YDB не поддерживает такой pushdown/cast
-    }
-
     @Override
     protected TestTable createTableWithDefaultColumns() {
         return new TestTable(


### PR DESCRIPTION
## Pull request type

- [x] Other: test coverage restoration

## What is the current behavior?

`testVarcharCastToDateInPredicate` is an empty override, so the inherited Trino 483 predicate contract is not run.

Issue Number: N/A

## What is the new behavior?

- Removes only the empty override.
- Restores the inherited contract for Text/varchar-to-date predicates.
- Removes the obsolete roadmap reference to that override.

## Validation

- `JAVA_HOME=$(/usr/libexec/java_home -v 25) mvn -f ydb-trino-adapter/pom.xml -DskipTests compile` — passed.
- Focused inherited test was attempted once with the CI Colima variables but was blocked before its body by YDB/Testcontainers initialization (`ProxyYdbHelper` received null; Docker environment discovery unavailable): 1 run, 0 failures, 1 error, 0 skipped.
- Full suite was not run because the Docker environment is unavailable.

No production code or custom tests were added.