### PR TITLE
Restore BCE date predicate contract

### DIFF
--- a/ydb-trino-adapter/ROADMAP.md
+++ b/ydb-trino-adapter/ROADMAP.md
@@ -136,7 +136,9 @@ unsupported behavior, record:
 2. an authoritative documentation link or tracked upstream issue;
 3. a focused negative test that proves the connector fails clearly.
 
-The existing negative-date overrides need this treatment.
+The remaining negative-date overrides need this treatment. Date predicates with
+BCE bounds stay in Trino as residual filters so they do not bind an unsupported
+value to YDB.
 YDB `Date` starts at the Unix epoch; see
 [primitive types](https://ydb.tech/docs/en/yql/reference/types/primitive).
 CHAR is rejected with the focused inherited contract

--- a/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
+++ b/ydb-trino-adapter/src/main/java/tech/ydb/trino/YdbClient.java
@@ -374,7 +374,13 @@ public class YdbClient extends BaseJdbcClient {
         return ColumnMapping.longMapping(
                 DATE,
                 dateReadFunctionUsingLocalDate(),
-                dateWriteFunctionUsingLocalDate());
+                dateWriteFunctionUsingLocalDate(),
+                (session, domain) -> domain.getValues().getRanges().getOrderedRanges().stream()
+                        .anyMatch(range ->
+                                (!range.isLowUnbounded() && (long) range.getLowBoundedValue() < 0) ||
+                                        (!range.isHighUnbounded() && (long) range.getHighBoundedValue() < 0))
+                        ? DISABLE_PUSHDOWN.apply(session, domain)
+                        : FULL_PUSHDOWN.apply(session, domain));
     }
 
     private static ColumnMapping timestampColumnMapping() {

--- a/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
+++ b/ydb-trino-adapter/src/test/java/tech/ydb/trino/TestYdbConnectorTest.java
@@ -91,12 +91,6 @@ public class TestYdbConnectorTest extends BaseConnectorTest {
 
     @Test
     @Override
-    public void testDateYearOfEraPredicate() {
-        // YDB не поддерживает, negative daysSinceEpoch
-    }
-
-    @Test
-    @Override
     public void testCreateTableAsSelectNegativeDate() {
         // YDB не поддерживает, negative daysSinceEpoch
     }


### PR DESCRIPTION
## Summary

- restore Trino 483 inherited `testDateYearOfEraPredicate`
- keep BCE `Date` bounds as Trino residual filters, avoiding invalid YDB `Date` JDBC bindings
- preserve pushdown for date predicates whose bounds are non-negative

## Validation

- JDK 25: `mvn -f ydb-trino-adapter/pom.xml -DskipTests compile`
- JDK 25: `mvn -f ydb-trino-adapter/pom.xml -DskipTests test`
- `git diff --check`

Local Docker/Testcontainers runtime was not run because the known Colima initialization is unavailable. CI must pass before readiness.
