### PR TITLE
Update Trino adapter to YDB JDBC 2.4.1

### DIFF
--- a/ydb-trino-adapter/pom.xml
+++ b/ydb-trino-adapter/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>25</maven.compiler.release>
         <trino.version>483</trino.version>
-        <ydb.jdbc.version>2.3.18</ydb.jdbc.version>
+        <ydb.jdbc.version>2.4.1</ydb.jdbc.version>
         <ydb.sdk.version>2.3.13</ydb.sdk.version>
         <junit.version>5.10.1</junit.version>
     </properties>


### PR DESCRIPTION
Updates the Trino adapter's shaded YDB JDBC driver from 2.3.18 to [2.4.1](https://github.com/ydb-platform/ydb-jdbc-driver/releases/tag/v2.4.1), the latest stable release published on GitHub and Maven Central. The driver bundles YDB SDK 2.4.10. The existing connection-cache override and test helper version remain in place.

The diff changes one dependency property: 1 addition and 1 deletion.

Validation:

- Temurin 25.0.2: production and test compilation passed (16 main sources, 5 test sources).
- Resolved dependency tree and test classpath checked; the shaded driver resolves to 2.4.1.
- Independent source review passed for `f0d1a51bbec2b4e5d2973e2d549fc907078f6472`.
- [Full adapter CI on Temurin 25](https://github.com/ydb-platform/ydb-java-dialects/actions/runs/34593119629) passed: 307 tests, 222 passed, 85 skipped, 0 failures, 0 errors. Existing tests, capability declarations, and CI configuration are unchanged.
- CI tested this head merged with main `6fb112f65c82b728ec1ea141df713ca029bf2253`. Local integration tests were not started because the Docker API timed out; runtime validation comes from the full CI run above.
